### PR TITLE
Use `--no-write-lock-file` for nix invocations to prevent creating lo…

### DIFF
--- a/src/flake_info.rs
+++ b/src/flake_info.rs
@@ -51,6 +51,7 @@ pub(crate) async fn get_flake_metadata(directory: &Path) -> color_eyre::Result<s
         .arg("flake")
         .arg("metadata")
         .arg("--json")
+        .arg("--no-write-lock-file")
         .arg(directory)
         .output()
         .await
@@ -85,6 +86,7 @@ pub(crate) async fn get_flake_tarball_outputs(
         .arg("flake")
         .arg("show")
         .arg("--json")
+        .arg("--no-write-lock-file")
         .arg(&file_protocol_path)
         .output()
         .await


### PR DESCRIPTION
…ckfiles that didn't exist

Before this, if there were any repos without a flake.lock (i.e. because the locking should be decided by the consumer), these commands would create a flake.lock regardless, leading to weird issues.

After this, if the repo did not have a flake.lock, nor will its tarball.

---

Depends on #6.