### PR TITLE
Allow manually specifying owner/repo database ids in debug mode

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -61,10 +61,10 @@ pub struct DevConfig {
     pub(crate) dev_bearer_token: OptionString,
     // A manually-specified project id (a la GitHub's `databaseId`)
     #[clap(long)]
-    pub(crate) dev_project_id: Option<i64>,
+    pub(crate) dev_project_id: Option<String>,
     // A manually-specified owner id (a la GitHub's `databaseId`)
     #[clap(long)]
-    pub(crate) dev_owner_id: Option<i64>,
+    pub(crate) dev_owner_id: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -23,8 +23,8 @@ pub(crate) struct ReleaseMetadata {
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub(crate) struct DevMetadata {
-    pub(crate) project_id: Option<i64>,
-    pub(crate) owner_id: Option<i64>,
+    pub(crate) project_id: Option<String>,
+    pub(crate) owner_id: Option<String>,
 }
 
 impl ReleaseMetadata {


### PR DESCRIPTION
Makes mocking stuff after https://github.com/DeterminateSystems/nxfr/pull/30 easier.