### PR TITLE
Render README as HTML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ammonia"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e6d1c7838db705c9b756557ee27c384ce695a1c51a6fe528784cb1c6840170"
+dependencies = [
+ "html5ever",
+ "maplit",
+ "once_cell",
+ "tendril",
+ "url",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +228,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
+name = "cargo-registry-markdown"
+version = "0.0.0"
+dependencies = [
+ "ammonia",
+ "comrak",
+ "htmlescape",
+ "url",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +345,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "comrak"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482aa5695bca086022be453c700a40c02893f1ba7098a2c88351de55341ae894"
+dependencies = [
+ "entities",
+ "memchr",
+ "once_cell",
+ "regex",
+ "slug",
+ "typed-arena",
+ "unicode_categories",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +477,12 @@ checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "errno"
@@ -500,6 +559,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -1405,6 +1474,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1724,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1894,7 @@ version = "0.1.0"
 dependencies = [
  "atty",
  "base64",
+ "cargo-registry-markdown",
  "clap",
  "color-eyre",
  "flate2",
@@ -1860,6 +1982,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +2030,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -1897,6 +2069,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1945,6 +2147,8 @@ version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax 0.7.2",
 ]
 
@@ -2230,12 +2434,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
+dependencies = [
+ "deunicode",
 ]
 
 [[package]]
@@ -2268,6 +2487,32 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -2320,6 +2565,17 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -2548,6 +2804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "uluru"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +2846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2876,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cargo-registry-markdown = { path = "./cargo-registry-markdown" }
 clap = { version = "4.3.4", features = ["derive", "env"] }
 color-eyre = { version = "0.6.2", default-features = false, features = [ "track-caller", "issue-url", "tracing-error", "capture-spantrace", "color-spantrace" ] }
 graphql_client = { version = "0.13.0" }

--- a/cargo-registry-markdown/Cargo.toml
+++ b/cargo-registry-markdown/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cargo-registry-markdown"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/crates.io"
+description = "crates.io markdown renderer"
+edition = "2021"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+ammonia = "3.3.0"
+comrak = { version = "0.18.0", default-features = false }
+htmlescape = "0.3.1"
+url = "2.3.1"

--- a/cargo-registry-markdown/lib.rs
+++ b/cargo-registry-markdown/lib.rs
@@ -1,0 +1,595 @@
+//! Render Markdown files to HTML.
+
+use ammonia::{Builder, UrlRelative, UrlRelativeEvaluate};
+use comrak::nodes::{AstNode, NodeValue};
+use htmlescape::encode_minimal;
+use std::borrow::Cow;
+use std::path::Path;
+use url::Url;
+
+/// Context for markdown to HTML rendering.
+struct MarkdownRenderer<'a> {
+    html_sanitizer: Builder<'a>,
+}
+
+impl<'a> MarkdownRenderer<'a> {
+    /// Creates a new renderer instance.
+    ///
+    /// Per `text_to_html`, `base_url` is the base URL prepended to any
+    /// relative links in the input document.  See that function for more detail.
+    fn new(base_url: Option<&'a str>, base_dir: &'a str) -> MarkdownRenderer<'a> {
+        let allowed_classes = hashmap(&[(
+            "code",
+            hashset(&[
+                "language-bash",
+                "language-clike",
+                "language-glsl",
+                "language-go",
+                "language-ini",
+                "language-javascript",
+                "language-json",
+                "language-markup",
+                "language-protobuf",
+                "language-ruby",
+                "language-rust",
+                "language-scss",
+                "language-sql",
+                "language-toml",
+                "language-yaml",
+            ]),
+        )]);
+        let sanitize_url = UrlRelative::Custom(Box::new(SanitizeUrl::new(base_url, base_dir)));
+
+        let mut html_sanitizer = Builder::default();
+        html_sanitizer
+            .add_tags(&["input"])
+            .link_rel(Some("nofollow noopener noreferrer"))
+            .add_generic_attributes(&["align"])
+            .add_tag_attributes("a", &["id", "target"])
+            .add_tag_attributes("input", &["checked", "disabled", "type"])
+            .allowed_classes(allowed_classes)
+            .url_relative(sanitize_url)
+            .id_prefix(Some("user-content-"));
+        MarkdownRenderer { html_sanitizer }
+    }
+
+    /// Renders the given markdown to HTML using the current settings.
+    fn to_html(&self, text: &str) -> String {
+        use comrak::{
+            format_html, parse_document, Arena, ComrakExtensionOptions, ComrakOptions,
+            ComrakRenderOptions,
+        };
+
+        let options = ComrakOptions {
+            render: ComrakRenderOptions {
+                unsafe_: true, // The output will be sanitized with `ammonia`
+                ..ComrakRenderOptions::default()
+            },
+            extension: ComrakExtensionOptions {
+                autolink: true,
+                strikethrough: true,
+                table: true,
+                tagfilter: true,
+                tasklist: true,
+                header_ids: Some("user-content-".to_string()),
+                ..ComrakExtensionOptions::default()
+            },
+            ..ComrakOptions::default()
+        };
+
+        let arena = Arena::new();
+        let root = parse_document(&arena, text, &options);
+
+        // Tweak annotations of code blocks.
+        iter_nodes(root, &|node| {
+            if let NodeValue::CodeBlock(ref mut ncb) = node.data.borrow_mut().value {
+                let orig_annot = ncb.info.as_str();
+
+                // Ignore characters after a comma for syntax highlighting to work correctly.
+                if let Some((before_comma, _)) = orig_annot.split_once(',') {
+                    ncb.info = before_comma.to_string();
+                }
+            }
+        });
+
+        let mut html = Vec::new();
+        format_html(root, &options, &mut html).unwrap();
+        let rendered = String::from_utf8(html).unwrap();
+        self.html_sanitizer.clean(&rendered).to_string()
+    }
+}
+
+/// Iterate the nodes in the CommonMark AST, used in comrak.
+fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
+where
+    F: Fn(&'a AstNode<'a>),
+{
+    f(node);
+    for c in node.children() {
+        iter_nodes(c, f);
+    }
+}
+
+/// Add trailing slash and remove `.git` suffix of base URL.
+fn canon_base_url(mut base_url: String) -> String {
+    if !base_url.ends_with('/') {
+        base_url.push('/');
+    }
+    if base_url.ends_with(".git/") {
+        let offset = base_url.len() - 5;
+        base_url.drain(offset..offset + 4);
+    }
+    base_url
+}
+
+/// Sanitize relative URLs in Markdown files.
+struct SanitizeUrl {
+    base_url: Option<String>,
+    base_dir: String,
+}
+
+impl SanitizeUrl {
+    fn new(base_url: Option<&str>, base_dir: &str) -> Self {
+        let base_url = base_url
+            .and_then(|base_url| Url::parse(base_url).ok())
+            .and_then(|url| match url.host_str() {
+                Some("github.com") | Some("gitlab.com") | Some("bitbucket.org") => {
+                    Some(canon_base_url(url.into()))
+                }
+                _ => None,
+            });
+        Self {
+            base_url,
+            base_dir: base_dir.to_owned(),
+        }
+    }
+}
+
+/// Groups media-related URL info
+struct MediaUrl {
+    is_media: bool,
+    add_sanitize_query: bool,
+}
+
+/// Determine whether the given URL has a media file extension.
+/// Also check if `sanitize=true` must be added to the query string,
+/// which is required to load SVGs properly from GitHub.
+fn is_media_url(url: &str) -> MediaUrl {
+    Path::new(url)
+        .extension()
+        .and_then(std::ffi::OsStr::to_str)
+        .map_or(
+            MediaUrl {
+                is_media: false,
+                add_sanitize_query: false,
+            },
+            |e| match e {
+                "svg" => MediaUrl {
+                    is_media: true,
+                    add_sanitize_query: true,
+                },
+                "png" | "jpg" | "jpeg" | "gif" | "mp4" | "webm" | "ogg" | "webp" => MediaUrl {
+                    is_media: true,
+                    add_sanitize_query: false,
+                },
+                _ => MediaUrl {
+                    is_media: false,
+                    add_sanitize_query: false,
+                },
+            },
+        )
+}
+
+impl UrlRelativeEvaluate for SanitizeUrl {
+    fn evaluate<'a>(&self, url: &'a str) -> Option<Cow<'a, str>> {
+        if url.starts_with('#') {
+            // Always allow fragment URLs.
+            return Some(Cow::Borrowed(url));
+        }
+
+        if url.starts_with("::") {
+            // Always reject relative rustdoc URLs.
+            return None;
+        }
+
+        self.base_url.as_ref().map(|base_url| {
+            let mut new_url = base_url.clone();
+            // Assumes GitHub’s URL scheme. GitHub renders text and markdown
+            // better in the "blob" view, but images need to be served raw.
+            let MediaUrl {
+                is_media,
+                add_sanitize_query,
+            } = is_media_url(url);
+            new_url += if is_media { "raw/HEAD" } else { "blob/HEAD" };
+            if !self.base_dir.is_empty() {
+                new_url += "/";
+                new_url += &self.base_dir;
+            }
+            if !url.starts_with('/') {
+                new_url.push('/');
+            }
+            new_url += url;
+            if add_sanitize_query {
+                if let Ok(mut parsed_url) = Url::parse(&new_url) {
+                    parsed_url.query_pairs_mut().append_pair("sanitize", "true");
+                    new_url = parsed_url.into();
+                }
+            }
+            Cow::Owned(new_url)
+        })
+    }
+}
+
+/// Renders Markdown text to sanitized HTML with a given `base_url`.
+/// See `text_to_html` for the interpretation of `base_url`.
+fn markdown_to_html(text: &str, base_url: Option<&str>, base_dir: &str) -> String {
+    let renderer = MarkdownRenderer::new(base_url, base_dir);
+    renderer.to_html(text)
+}
+
+/// Any file with a filename ending in one of these extensions will be rendered as Markdown.
+/// Note we also render a file as Markdown if _no_ extension is on the filename.
+static MARKDOWN_EXTENSIONS: [&str; 7] =
+    ["md", "markdown", "mdown", "mdwn", "mkd", "mkdn", "mkdown"];
+
+/// Renders a text file to sanitized HTML.  An appropriate rendering method is chosen depending
+/// on the extension of the supplied `filename`.
+///
+/// The returned text will not contain any harmful HTML tag or attribute (such as iframe,
+/// onclick, onmouseover, etc.).
+///
+/// The `base_url` parameter will be used as the base for any relative links found in the
+/// Markdown, as long as its host part is github.com, gitlab.com, or bitbucket.org.  The
+/// supplied URL will be used as a directory base whether or not the relative link is
+/// prefixed with '/'.  If `None` is passed, relative links will be omitted.
+///
+/// # Examples
+///
+/// ```
+/// use cargo_registry_markdown::text_to_html;
+///
+/// let text = "[Rust](https://rust-lang.org/) is an awesome *systems programming* language!";
+/// let rendered = text_to_html(text, "README.md", None, None);
+/// assert_eq!(rendered, "<p><a href=\"https://rust-lang.org/\" rel=\"nofollow noopener noreferrer\">Rust</a> is an awesome <em>systems programming</em> language!</p>\n");
+/// ```
+pub fn text_to_html(
+    text: &str,
+    readme_path_in_pkg: &str,
+    base_url: Option<&str>,
+    pkg_path_in_vcs: Option<&str>,
+) -> String {
+    let path_in_vcs = Path::new(pkg_path_in_vcs.unwrap_or("")).join(readme_path_in_pkg);
+    let base_dir = path_in_vcs.parent().and_then(|p| p.to_str()).unwrap_or("");
+
+    if path_in_vcs.extension().is_none() {
+        return markdown_to_html(text, base_url, base_dir);
+    }
+
+    if let Some(ext) = path_in_vcs.extension().and_then(|ext| ext.to_str()) {
+        if MARKDOWN_EXTENSIONS.contains(&ext.to_lowercase().as_str()) {
+            return markdown_to_html(text, base_url, base_dir);
+        }
+    }
+
+    encode_minimal(text).replace('\n', "<br>\n")
+}
+
+/// Helper function to build a new `HashSet` from the items slice.
+fn hashset<T>(items: &[T]) -> std::collections::HashSet<T>
+where
+    T: Clone + Eq + std::hash::Hash,
+{
+    items.iter().cloned().collect()
+}
+
+/// Helper function to build a new `HashMap` from a slice of key-value pairs.
+fn hashmap<K, V>(items: &[(K, V)]) -> std::collections::HashMap<K, V>
+where
+    K: Clone + Eq + std::hash::Hash,
+    V: Clone,
+{
+    items.iter().cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_text() {
+        let text = "";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn text_with_script_tag() {
+        let text = "foo_readme\n\n<script>alert('Hello World')</script>";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<p>foo_readme</p>\n&lt;script&gt;alert(\'Hello World\')&lt;/script&gt;\n"
+        );
+    }
+
+    #[test]
+    fn text_with_iframe_tag() {
+        let text = "foo_readme\n\n<iframe>alert('Hello World')</iframe>";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<p>foo_readme</p>\n&lt;iframe&gt;alert(\'Hello World\')&lt;/iframe&gt;\n"
+        );
+    }
+
+    #[test]
+    fn text_with_unknown_tag() {
+        let text = "foo_readme\n\n<unknown>alert('Hello World')</unknown>";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(result, "<p>foo_readme</p>\n<p>alert(\'Hello World\')</p>\n");
+    }
+
+    #[test]
+    fn text_with_kbd_tag() {
+        let text = "foo_readme\n\nHello <kbd>alert('Hello World')</kbd>";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<p>foo_readme</p>\n<p>Hello <kbd>alert(\'Hello World\')</kbd></p>\n"
+        );
+    }
+
+    #[test]
+    fn text_with_inline_javascript() {
+        let text = r#"foo_readme\n\n<a href="https://crates.io/crates/cargo-registry" onclick="window.alert('Got you')">Crate page</a>"#;
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<p>foo_readme\\n\\n<a href=\"https://crates.io/crates/cargo-registry\" rel=\"nofollow noopener noreferrer\">Crate page</a></p>\n"
+        );
+    }
+
+    // See https://github.com/kivikakk/comrak/issues/37. This panic happened
+    // in comrak 0.1.8 but was fixed in 0.1.9.
+    #[test]
+    fn text_with_fancy_single_quotes() {
+        let text = "wb’";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(result, "<p>wb’</p>\n");
+    }
+
+    #[test]
+    fn code_block_with_syntax_highlighting() {
+        let code_block = r#"```rust \
+                            println!("Hello World"); \
+                           ```"#;
+        let result = markdown_to_html(code_block, None, "");
+        assert!(result.contains("<code class=\"language-rust\">"));
+    }
+
+    #[test]
+    fn code_block_with_syntax_highlighting_even_if_annot_has_no_run() {
+        let code_block = r#"```rust  ,  no_run \
+                            println!("Hello World"); \
+                           ```"#;
+        let result = markdown_to_html(code_block, None, "");
+        assert!(result.contains("<code class=\"language-rust\">"));
+    }
+
+    #[test]
+    fn text_with_forbidden_class_attribute() {
+        let text = "<p class='bad-class'>Hello World!</p>";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(result, "<p>Hello World!</p>\n");
+    }
+
+    #[test]
+    fn relative_links() {
+        let absolute = "[hi](/hi)";
+        let relative = "[there](there)";
+        let image = "![alt](img.png)";
+        let html_image = "<img src=\"img.png\" alt=\"alt\">";
+        let svg = "![alt](sanitize.svg)";
+
+        for host in &["github.com", "gitlab.com", "bitbucket.org"] {
+            for (&extra_slash, &dot_git) in [true, false].iter().zip(&[true, false]) {
+                let url = format!(
+                    "https://{}/rust-lang/test{}{}",
+                    host,
+                    if dot_git { ".git" } else { "" },
+                    if extra_slash { "/" } else { "" },
+                );
+
+                let result = markdown_to_html(absolute, Some(&url), "");
+                assert_eq!(
+                    result,
+                    format!(
+                        "<p><a href=\"https://{host}/rust-lang/test/blob/HEAD/hi\" rel=\"nofollow noopener noreferrer\">hi</a></p>\n"
+                    )
+                );
+
+                let result = markdown_to_html(relative, Some(&url), "");
+                assert_eq!(
+                    result,
+                    format!(
+                        "<p><a href=\"https://{host}/rust-lang/test/blob/HEAD/there\" rel=\"nofollow noopener noreferrer\">there</a></p>\n"
+                    )
+                );
+
+                let result = markdown_to_html(image, Some(&url), "");
+                assert_eq!(
+                    result,
+                    format!(
+                        "<p><img src=\"https://{host}/rust-lang/test/raw/HEAD/img.png\" alt=\"alt\"></p>\n",
+                    )
+                );
+
+                let result = markdown_to_html(html_image, Some(&url), "");
+                assert_eq!(
+                    result,
+                    format!(
+                        "<img src=\"https://{host}/rust-lang/test/raw/HEAD/img.png\" alt=\"alt\">\n",
+                    )
+                );
+
+                let result = markdown_to_html(svg, Some(&url), "");
+                assert_eq!(
+                    result,
+                    format!(
+                        "<p><img src=\"https://{host}/rust-lang/test/raw/HEAD/sanitize.svg?sanitize=true\" alt=\"alt\"></p>\n",
+                    )
+                );
+
+                let result = markdown_to_html(svg, Some(&url), "subdir");
+                assert_eq!(
+                    result,
+                    format!(
+                        "<p><img src=\"https://{host}/rust-lang/test/raw/HEAD/subdir/sanitize.svg?sanitize=true\" alt=\"alt\"></p>\n",
+                    )
+                );
+
+                let result = markdown_to_html(svg, Some(&url), "subdir1/subdir2");
+                assert_eq!(
+                    result,
+                    format!(
+                        "<p><img src=\"https://{host}/rust-lang/test/raw/HEAD/subdir1/subdir2/sanitize.svg?sanitize=true\" alt=\"alt\"></p>\n",
+                    )
+                );
+            }
+        }
+
+        let result = markdown_to_html(absolute, Some("https://google.com/"), "");
+        assert_eq!(
+            result,
+            "<p><a rel=\"nofollow noopener noreferrer\">hi</a></p>\n"
+        );
+    }
+
+    #[test]
+    fn absolute_links_dont_get_resolved() {
+        let text =
+            "[![Crates.io](https://img.shields.io/crates/v/clap.svg)](https://crates.io/crates/clap)";
+        let repository = "https://github.com/kbknapp/clap-rs/";
+        let result = markdown_to_html(text, Some(repository), "");
+
+        assert_eq!(
+            result,
+            "<p><a href=\"https://crates.io/crates/clap\" rel=\"nofollow noopener noreferrer\"><img src=\"https://img.shields.io/crates/v/clap.svg\" alt=\"Crates.io\"></a></p>\n"
+        );
+    }
+
+    #[test]
+    fn rustdoc_links() {
+        let repository = "https://github.com/foo/bar/";
+
+        assert_eq!(
+            markdown_to_html("[stylish](::stylish)", Some(repository), ""),
+            "<p><a rel=\"nofollow noopener noreferrer\">stylish</a></p>\n"
+        );
+
+        assert_eq!(
+            markdown_to_html("[Display](stylish::Display)", Some(repository), ""),
+            "<p><a rel=\"nofollow noopener noreferrer\">Display</a></p>\n"
+        );
+    }
+
+    #[test]
+    fn text_to_html_renders_markdown() {
+        for f in &[
+            "README",
+            "readme.md",
+            "README.MARKDOWN",
+            "whatever.mkd",
+            "s/readme.md",
+            "s1/s2/readme.md",
+        ] {
+            assert_eq!(
+                text_to_html("*lobster*", f, None, None),
+                "<p><em>lobster</em></p>\n"
+            );
+        }
+
+        assert_eq!(
+            text_to_html("*[lobster](docs/lobster)*", "readme.md", Some("https://github.com/rust-lang/test"), None),
+            "<p><em><a href=\"https://github.com/rust-lang/test/blob/HEAD/docs/lobster\" rel=\"nofollow noopener noreferrer\">lobster</a></em></p>\n"
+        );
+        assert_eq!(
+            text_to_html("*[lobster](docs/lobster)*", "s/readme.md", Some("https://github.com/rust-lang/test"), None),
+            "<p><em><a href=\"https://github.com/rust-lang/test/blob/HEAD/s/docs/lobster\" rel=\"nofollow noopener noreferrer\">lobster</a></em></p>\n"
+        );
+        assert_eq!(
+            text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), None),
+            "<p><em><a href=\"https://github.com/rust-lang/test/blob/HEAD/s1/s2/docs/lobster\" rel=\"nofollow noopener noreferrer\">lobster</a></em></p>\n"
+        );
+        assert_eq!(
+            text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), Some("path/in/vcs/")),
+            "<p><em><a href=\"https://github.com/rust-lang/test/blob/HEAD/path/in/vcs/s1/s2/docs/lobster\" rel=\"nofollow noopener noreferrer\">lobster</a></em></p>\n"
+        );
+        assert_eq!(
+            text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), Some("path/in/vcs")),
+            "<p><em><a href=\"https://github.com/rust-lang/test/blob/HEAD/path/in/vcs/s1/s2/docs/lobster\" rel=\"nofollow noopener noreferrer\">lobster</a></em></p>\n"
+        );
+    }
+
+    #[test]
+    fn text_to_html_renders_other_things() {
+        for f in &["readme.exe", "readem.org", "blah.adoc"] {
+            assert_eq!(
+                text_to_html("<script>lobster</script>\n\nis my friend\n", f, None, None),
+                "&lt;script&gt;lobster&lt;/script&gt;<br>\n<br>\nis my friend<br>\n"
+            );
+        }
+    }
+
+    #[test]
+    fn header_has_tags() {
+        let text = "# My crate\n\nHello, world!\n";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<h1><a href=\"#my-crate\" id=\"user-content-my-crate\" rel=\"nofollow noopener noreferrer\"></a>My crate</h1>\n<p>Hello, world!</p>\n"
+        );
+    }
+
+    #[test]
+    fn manual_anchor_is_sanitized() {
+        let text =
+            "<h1><a href=\"#my-crate\" id=\"my-crate\"></a>My crate</h1>\n<p>Hello, world!</p>\n";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<h1><a href=\"#my-crate\" id=\"user-content-my-crate\" rel=\"nofollow noopener noreferrer\"></a>My crate</h1>\n<p>Hello, world!</p>\n"
+        );
+    }
+
+    #[test]
+    fn tables_with_rowspan_and_colspan() {
+        let text = "<table><tr><th rowspan=\"1\" colspan=\"2\">Target</th></tr></table>\n";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<table><tbody><tr><th rowspan=\"1\" colspan=\"2\">Target</th></tr></tbody></table>\n"
+        );
+    }
+
+    #[test]
+    fn text_alignment() {
+        let text = "<h1 align=\"center\">foo-bar</h1>\n<h5 align=\"center\">Hello World!</h5>\n";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<h1 align=\"center\">foo-bar</h1>\n<h5 align=\"center\">Hello World!</h5>\n"
+        );
+    }
+
+    #[test]
+    fn image_alignment() {
+        let text =
+            "<p align=\"center\"><img src=\"https://img.shields.io/crates/v/clap.svg\" alt=\"\"></p>\n";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(
+            result,
+            "<p align=\"center\"><img src=\"https://img.shields.io/crates/v/clap.svg\" alt=\"\"></p>\n"
+        );
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
 
   outputs = inputs:
     let
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
 
       forAllSystems = forSystems supportedSystems;
       forDockerSystems = forSystems [ "x86_64-linux" ];
@@ -36,7 +36,6 @@
       overlays.default = final: prev: {
         nxfr-push = inputs.self.packages.${final.stdenv.system}.nxfr-push;
       };
-
 
       packages = forAllSystems ({ system, pkgs, lib, ... }:
         let
@@ -70,7 +69,8 @@
             rustc
             cargo
           ]
-          ++ inputs.self.packages.${system}.nxfr-push.buildInputs;
+          ++ inputs.self.packages.${system}.nxfr-push.buildInputs
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ Security ]);
 
           nativeBuildInputs = with pkgs; [
           ]

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -97,7 +97,9 @@ impl ReleaseMetadata {
 
         let readme_path = directory.join("README.md");
         let readme = if readme_path.exists() {
-            Some(tokio::fs::read_to_string(readme_path).await?)
+            let file = tokio::fs::read_to_string(readme_path).await?;
+            let html = cargo_registry_markdown::text_to_html(&file, "README.md", None, None);
+            Some(html)
         } else {
             None
         };


### PR DESCRIPTION
This is currently being handled on the server side but at the cost of rendering HTML on the fly on a per-request basis, which is likely to degrade UX. Better to store pre-rendered HTML in the database. Rendering at this stage also enables us to do any necessary sussing or scrubbing long before the server touches it.