### PR TITLE
Allow manually specifying a SPDX expression for licensing

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -58,6 +58,11 @@ inputs:
       You can add up to five extra tags; tags beyond the first five will be ignored.
     required: false
     default: ""
+  spdx-expression:
+    description: A valid SPDX license expression. This will be used in place of what GitHub claims your repository's `spdxIdentifier` is.
+    required: false
+    default: ""
+
   flakehub-push-binary:
     description: Run a version of the `flakehub-push` binary from somewhere already on disk. Conflicts with all other `flakehub-push-*` options.
   flakehub-push-branch:
@@ -97,6 +102,7 @@ runs:
       FLAKEHUB_PUSH_DIRECTORY: ${{ inputs.directory }}
       FLAKEHUB_PUSH_GIT_ROOT: ${{ inputs.git-root }}
       FLAKEHUB_PUSH_EXTRA_TAGS: ${{ inputs.extra-tags }}
+      FLAKEHUB_PUSH_SPDX_EXPRESSION: ${{ inputs.spdx-expression }}
       # Also GITHUB_REPOSITORY, GITHUB_REF_NAME, GITHUB_TOKEN, ACTIONS_ID_TOKEN_REQUEST_TOKEN, ACTIONS_ID_TOKEN_REQUEST_URL
     run: |
       if [ "${RUNNER_OS}" == "Linux" ]; then

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -67,6 +67,14 @@ pub(crate) struct NixfrPushCli {
     )]
     pub(crate) extra_tags: Vec<String>,
 
+    /// An SPDX expression that overrides that which is returned from GitHub.
+    #[clap(
+        long,
+        env = "FLAKEHUB_PUSH_SPDX_EXPRESSION",
+        value_parser = SpdxToNoneParser
+    )]
+    pub(crate) spdx_expression: OptionSpdxExpression,
+
     #[clap(flatten)]
     pub instrumentation: instrumentation::Instrumentation,
 }
@@ -123,6 +131,34 @@ impl clap::builder::TypedValueParser for PathBufToNoneParser {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct OptionSpdxExpression(pub Option<spdx::Expression>);
+
+#[derive(Clone)]
+struct SpdxToNoneParser;
+
+impl clap::builder::TypedValueParser for SpdxToNoneParser {
+    type Value = OptionSpdxExpression;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let inner = clap::builder::StringValueParser::new();
+        let val = inner.parse_ref(cmd, arg, value)?;
+
+        if val.is_empty() {
+            Ok(OptionSpdxExpression(None))
+        } else {
+            let expression = spdx::Expression::parse(&val)
+                .map_err(|_| clap::Error::new(clap::error::ErrorKind::ValueValidation))?;
+            Ok(OptionSpdxExpression(Some(expression)))
+        }
+    }
+}
+
 fn build_http_client() -> reqwest::ClientBuilder {
     reqwest::Client::builder().user_agent("flakehub-push")
 }
@@ -148,6 +184,7 @@ impl NixfrPushCli {
             jwt_issuer_uri,
             instrumentation: _,
             extra_tags,
+            spdx_expression,
         } = self;
 
         let github_token = if let Some(github_token) = &github_token.0 {
@@ -281,6 +318,7 @@ impl NixfrPushCli {
             rolling_prefix.0.as_deref(),
             github_graphql_data_result,
             extra_tags,
+            spdx_expression.0,
         )
         .await?;
 
@@ -313,6 +351,7 @@ async fn push_new_release(
     rolling_prefix: Option<&str>,
     github_graphql_data_result: GithubGraphqlDataResult,
     extra_tags: Vec<String>,
+    spdx_expression: Option<spdx::Expression>,
 ) -> color_eyre::Result<()> {
     let span = tracing::Span::current();
     let upload_name = upload_name.unwrap_or(repository);
@@ -405,6 +444,7 @@ async fn push_new_release(
         visibility,
         github_graphql_data_result,
         extra_tags,
+        spdx_expression,
     )
     .await
     .wrap_err("Building release metadata")?;

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -100,6 +100,7 @@ impl ReleaseMetadata {
         visibility: Visibility,
         github_graphql_data_result: GithubGraphqlDataResult,
         extra_tags: Vec<String>,
+        spdx_expression: Option<spdx::Expression>,
     ) -> color_eyre::Result<ReleaseMetadata> {
         let span = tracing::Span::current();
 
@@ -134,8 +135,9 @@ impl ReleaseMetadata {
             None
         };
 
-        let spdx_identifier = if let Some(spdx_string) = github_graphql_data_result.spdx_identifier
-        {
+        let spdx_identifier = if spdx_expression.is_some() {
+            spdx_expression
+        } else if let Some(spdx_string) = github_graphql_data_result.spdx_identifier {
             let parsed = spdx::Expression::parse(&spdx_string)
                 .wrap_err("Invalid SPDX license identifier reported from the GitHub API, either you are using a non-standard license or GitHub has returned a value that cannot be validated")?;
             span.record("spdx_identifier", tracing::field::display(&parsed));


### PR DESCRIPTION
TODO: Change the backend to support `[]text` for the spdx_identifier, and rename it to `spdx_identifiers`