### PR TITLE
Change handling of HTTP 409 error

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -469,7 +469,7 @@ async fn push_new_release(
     tracing::debug!(%release_upload_url, "Got release upload URL");
 
     if release_metadata_post_response_status != StatusCode::OK {
-        if release_metadata_post_response_status == StatusCode::PRECONDITION_FAILED {
+        if release_metadata_post_response_status == StatusCode::CONFLICT {
             tracing::info!(
                 "Release for revision `{revision}` of {upload_name}/{rolling_prefix_or_tag} already exists; flakehub-push will not upload it again",
                 revision = release_metadata.revision


### PR DESCRIPTION
Right now `flakehub-push` fails when a release already exists. I think that it's likely to be quite frustrating for users to see red on otherwise successful CI runs. With the changes in this PR, the CLI logs an already-existing release at `INFO` level but doesn't fail.

Currently there is no HTTP 409 on the backend, but [PR #43 on the FlakeHub repo](https://github.com/DeterminateSystems/flakehub-push/pull/43/files) would change that.
