### PR TITLE
Filter out empty tags

### DIFF
--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -155,7 +155,7 @@ impl ReleaseMetadata {
             .collect::<HashSet<String>>()
             .into_iter()
             .take(MAX_NUM_TOTAL_TAGS)
-            .map(|s| s.to_lowercase())
+            .map(|s| s.trim().to_lowercase())
             .filter(|t: &String| {
                 !t.is_empty()
                     && t.len() <= MAX_TAG_LENGTH


### PR DESCRIPTION
I'm not sure if it's possible to add empty strings as tags but might as well cover that case. I suspect that `foo,bar,baz,` in the `extra-tags` parameter may do precisely that.
