### PR TITLE
fixup: default empty spdx_expression

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -72,7 +72,8 @@ pub(crate) struct NixfrPushCli {
     #[clap(
         long,
         env = "FLAKEHUB_PUSH_SPDX_EXPRESSION",
-        value_parser = SpdxToNoneParser
+        value_parser = SpdxToNoneParser,
+        default_value = ""
     )]
     pub(crate) spdx_expression: OptionSpdxExpression,
 


### PR DESCRIPTION
(So it's not required)