### PR TITLE
Default rolling-minor to null, not 1

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ inputs:
   rolling-minor:
     description: "Specify the SemVer minor version of your rolling releases. All releases will follow the versioning scheme '0.[rolling-minor].[commit count]+rev-[git sha]'"
     required: false
-    default: 1
+    default: null
   rolling:
     description: |
       For untagged releases, use a rolling versioning scheme.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -430,6 +430,11 @@ async fn push_new_release(
     span.record("upload_name", tracing::field::display(upload_name));
 
     let rolling_prefix_or_tag = match (rolling_minor.as_ref(), tag) {
+        (Some(_), _) if !rolling => {
+            return Err(eyre!(
+                "You must enable `rolling` to upload a release with a specific `rolling-minor`."
+            ));
+        }
         (Some(minor), _) => format!("0.{minor}"),
         (None, _) if rolling => DEFAULT_ROLLING_PREFIX.to_string(),
         (None, Some(tag)) => tag,


### PR DESCRIPTION
Since we treat specifying `rolling-minor` the same as if both `rolling-minor` and `rolling: true` were set, we can't set the minor to something real.