### PR TITLE
Set repository in flakehub-push

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "flakehub-push"
 # 0.0.x versions are used for dev pushes.
 version = "0.1.0"
 edition = "2021"
-repository = "https://github.com/DeterminateSystems/flakehub-push/"
+repository = "https://github.com/DeterminateSystems/flakehub-push"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
```rust
The application panicked (crashed).
Message:  uwu
Location: src/main.rs:23

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.

Consider reporting this error using this URL: https://github.com/DeterminateSystems/flakehub-push//issues/new?title=%3Cautogenerated-issue%3E&body=%23%23+Error%0A%60%60%60%0AWTF+MATE%3F%0A%60%60%60%0A%0A%23%23+Metadata%0A%7Ckey%7Cvalue%7C%0A%7C--%7C--%7C%0A%7C**version**%7C0.1.0%7C%0A%7C**os**%7Clinux%7C%0A%7C**arch**%7Cx86_64%7C%0A%7C**location**%7Csrc%2Fmain.rs%3A23%3A5%7C%0A
```