### PR TITLE
Set the mtime fields in the tarball correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,9 +2362,8 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+version = "0.4.40"
+source = "git+https://github.com/DeterminateSystems/tar-rs.git?branch=force-mtime#b25211be672398a005b39061ee35d28a2a3d7e8a"
 dependencies = [
  "filetime",
  "libc",
@@ -3002,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "0.2.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+checksum = "ea263437ca03c1522846a4ddafbca2542d0ad5ed9b784909d4b27b76f62bc34a"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.97"
 gix = { version = "0.46.0", features = ["async-network-client", "serde"] }
 gix-ref = { version = "0.30.0", features = ["serde"] }
-tar = { version = "0.4.38", features = ["xattr"] }
+#tar = { version = "0.4.38", features = ["xattr"] }
+tar = { git = "https://github.com/DeterminateSystems/tar-rs.git", branch = "force-mtime", features = ["xattr"] }
 flate2 = "1.0.26"
 tempfile = "3.6.0"
 ring = "0.16.20"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -519,7 +519,18 @@ async fn push_new_release(
     span.record("source", tracing::field::display(source.clone().display()));
     tracing::debug!("Found source");
 
-    let flake_tarball = get_flake_tarball(&source)
+    let last_modified = if let Some(last_modified) = flake_metadata.get("lastModified") {
+        last_modified.as_u64().ok_or_else(|| {
+            eyre!("`nix flake metadata --json` does not have a integer `lastModified` field")
+        })?
+    } else {
+        return Err(eyre!(
+            "`nix flake metadata` did not return a `lastModified` attribute"
+        ));
+    };
+    tracing::debug!("lastModified = {}", last_modified);
+
+    let flake_tarball = get_flake_tarball(&source, last_modified)
         .await
         .wrap_err("Making release tarball")?;
 

--- a/src/flake_info.rs
+++ b/src/flake_info.rs
@@ -13,9 +13,13 @@ const FLAKE_URL_PLACEHOLDER_UUID: &str = "c9026fc0-ced9-48e0-aa3c-fc86c4c86df1";
         directory = %directory.display(),
     )
 )]
-pub(crate) async fn get_flake_tarball(directory: &Path) -> color_eyre::Result<Vec<u8>> {
+pub(crate) async fn get_flake_tarball(
+    directory: &Path,
+    last_modified: u64,
+) -> color_eyre::Result<Vec<u8>> {
     let mut tarball_builder = tar::Builder::new(vec![]);
     tarball_builder.follow_symlinks(false);
+    tarball_builder.force_mtime(last_modified);
 
     tracing::trace!("Creating tarball");
     // `tar` works according to the current directory (yay)


### PR DESCRIPTION
This makes FlakeHub flakes behave consistently with GitHub flakes. Unfortunately, this requires a patched tar-rs crate.