### PR TITLE
Allow for case-insensitive README names

### DIFF
--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,5 +1,8 @@
 use color_eyre::eyre::{eyre, WrapErr};
-use std::{collections::HashSet, path::{Path, PathBuf}};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     graphql::{GithubGraphqlDataResult, MAX_NUM_TOTAL_TAGS, MAX_TAG_LENGTH},
@@ -226,8 +229,7 @@ where
 
 async fn get_readme(readme_dir: PathBuf) -> color_eyre::Result<Option<String>> {
     let mut readme_path: Option<String> = None;
-    let mut read_dir = tokio::fs::read_dir(readme_dir)
-        .await?;
+    let mut read_dir = tokio::fs::read_dir(readme_dir).await?;
 
     while let Ok(Some(entry)) = read_dir.next_entry().await {
         if entry.file_name().to_string_lossy().to_ascii_lowercase() == README_FILENAME_LOWERCASE {

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -234,13 +234,9 @@ async fn get_readme(readme_dir: PathBuf) -> color_eyre::Result<Option<String>> {
 
     while let Some(entry) = read_dir.next_entry().await? {
         if entry.file_name().to_ascii_lowercase() == README_FILENAME_LOWERCASE {
-            readme_path = Some(entry.file_name());
+            return Some(entry.file_name());
         }
     }
 
-    if let Some(path) = readme_path {
-        Ok(Some(tokio::fs::read_to_string(path).await?))
-    } else {
-        Ok(None)
-    }
+    Ok(None)
 }

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -139,15 +139,19 @@ impl ReleaseMetadata {
 
         let readme_dir = flake_root.join(subdir);
 
-        let readme = if let Some(Ok(path)) = std::fs::read_dir(readme_dir)?.find(|entry| match entry {
-            Ok(entry) => entry.file_name().to_string_lossy().to_ascii_lowercase() == README_FILENAME_LOWERCASE,
-            Err(_) => false,
-        }) {
+        let readme = if let Some(Ok(path)) =
+            std::fs::read_dir(readme_dir)?.find(|entry| match entry {
+                Ok(entry) => {
+                    entry.file_name().to_string_lossy().to_ascii_lowercase()
+                        == README_FILENAME_LOWERCASE
+                }
+                Err(_) => false,
+            }) {
             Some(tokio::fs::read_to_string(path.path()).await?)
         } else {
             None
         };
-        
+
         let spdx_identifier = if spdx_expression.is_some() {
             spdx_expression
         } else if let Some(spdx_string) = github_graphql_data_result.spdx_identifier {

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,7 +1,8 @@
 use color_eyre::eyre::{eyre, WrapErr};
 use std::{
     collections::HashSet,
-    path::{Path, PathBuf}, ffi::OsString,
+    ffi::OsString,
+    path::{Path, PathBuf},
 };
 
 use crate::{

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,7 +1,7 @@
 use color_eyre::eyre::{eyre, WrapErr};
 use std::{
     collections::HashSet,
-    path::{Path, PathBuf},
+    path::{Path, PathBuf}, ffi::OsString,
 };
 
 use crate::{
@@ -228,12 +228,12 @@ where
 }
 
 async fn get_readme(readme_dir: PathBuf) -> color_eyre::Result<Option<String>> {
-    let mut readme_path: Option<String> = None;
+    let mut readme_path: Option<OsString> = None;
     let mut read_dir = tokio::fs::read_dir(readme_dir).await?;
 
     while let Some(entry) = read_dir.next_entry().await? {
-        if entry.file_name().to_string_lossy().to_ascii_lowercase() == README_FILENAME_LOWERCASE {
-            readme_path = Some(entry.file_name().to_string_lossy().to_string());
+        if entry.file_name().to_ascii_lowercase() == README_FILENAME_LOWERCASE {
+            readme_path = Some(entry.file_name());
         }
     }
 

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -140,7 +140,7 @@ impl ReleaseMetadata {
         let readme_dir = flake_root.join(subdir);
 
         let readme = if let Some(Ok(path)) =
-            std::fs::read_dir(readme_dir)?.find(|entry| match entry {
+            tokio::fs::read_dir(readme_dir).await?.find(|entry| match entry {
                 Ok(entry) => {
                     entry.file_name().to_string_lossy().to_ascii_lowercase()
                         == README_FILENAME_LOWERCASE

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,7 +1,6 @@
 use color_eyre::eyre::{eyre, WrapErr};
 use std::{
     collections::HashSet,
-    ffi::OsString,
     path::{Path, PathBuf},
 };
 
@@ -229,12 +228,11 @@ where
 }
 
 async fn get_readme(readme_dir: PathBuf) -> color_eyre::Result<Option<String>> {
-    let mut readme_path: Option<OsString> = None;
     let mut read_dir = tokio::fs::read_dir(readme_dir).await?;
 
     while let Some(entry) = read_dir.next_entry().await? {
         if entry.file_name().to_ascii_lowercase() == README_FILENAME_LOWERCASE {
-            return Some(entry.file_name());
+            return Ok(Some(tokio::fs::read_to_string(entry.file_name()).await?));
         }
     }
 

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -231,7 +231,7 @@ async fn get_readme(readme_dir: PathBuf) -> color_eyre::Result<Option<String>> {
     let mut readme_path: Option<String> = None;
     let mut read_dir = tokio::fs::read_dir(readme_dir).await?;
 
-    while let Ok(Some(entry)) = read_dir.next_entry().await {
+    while let Some(entry) = read_dir.next_entry().await? {
         if entry.file_name().to_string_lossy().to_ascii_lowercase() == README_FILENAME_LOWERCASE {
             readme_path = Some(entry.file_name().to_string_lossy().to_string());
         }

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -144,6 +144,7 @@ impl ReleaseMetadata {
                 .await?
                 .find(|entry| match entry {
                     Ok(entry) => {
+                        // to_string_lossy() replaces unknown sequences with U+FFFD REPLACEMENT CHARACTER, which doesn't occur in "readme.md", so this shouldn't result in any false positives.
                         entry.file_name().to_string_lossy().to_ascii_lowercase()
                             == README_FILENAME_LOWERCASE
                     }

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -140,13 +140,15 @@ impl ReleaseMetadata {
         let readme_dir = flake_root.join(subdir);
 
         let readme = if let Some(Ok(path)) =
-            tokio::fs::read_dir(readme_dir).await?.find(|entry| match entry {
-                Ok(entry) => {
-                    entry.file_name().to_string_lossy().to_ascii_lowercase()
-                        == README_FILENAME_LOWERCASE
-                }
-                Err(_) => false,
-            }) {
+            tokio::fs::read_dir(readme_dir)
+                .await?
+                .find(|entry| match entry {
+                    Ok(entry) => {
+                        entry.file_name().to_string_lossy().to_ascii_lowercase()
+                            == README_FILENAME_LOWERCASE
+                    }
+                    Err(_) => false,
+                }) {
             Some(tokio::fs::read_to_string(path.path()).await?)
         } else {
             None


### PR DESCRIPTION
The Option/Result logic I use to suss this out is pretty gnarly. I'm open to suggestion on how to clean it up.
