### PR TITLE
Read README from flake's store path

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -613,7 +613,7 @@ async fn push_new_release(
         .wrap_err("Writing compressed tarball to tempfile")?;
 
     let release_metadata = ReleaseMetadata::build(
-        flake_root,
+        &source,
         subdir,
         revision_info,
         flake_metadata,

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -89,7 +89,7 @@ impl ReleaseMetadata {
     // FIXME
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip_all, fields(
-        flake_root = %flake_root.display(),
+        flake_store_path = %flake_store_path.display(),
         subdir = %subdir.display(),
         description = tracing::field::Empty,
         readme_path = tracing::field::Empty,
@@ -100,7 +100,7 @@ impl ReleaseMetadata {
         visibility = ?visibility,
     ))]
     pub(crate) async fn build(
-        flake_root: &Path,
+        flake_store_path: &Path,
         subdir: &Path,
         revision_info: RevisionInfo,
         flake_metadata: serde_json::Value,
@@ -140,7 +140,7 @@ impl ReleaseMetadata {
             None
         };
 
-        let readme_dir = flake_root.join(subdir);
+        let readme_dir = flake_store_path.join(subdir);
         let readme = get_readme(readme_dir).await?;
 
         let spdx_identifier = if spdx_expression.is_some() {
@@ -232,7 +232,7 @@ async fn get_readme(readme_dir: PathBuf) -> color_eyre::Result<Option<String>> {
 
     while let Some(entry) = read_dir.next_entry().await? {
         if entry.file_name().to_ascii_lowercase() == README_FILENAME_LOWERCASE {
-            return Ok(Some(tokio::fs::read_to_string(entry.file_name()).await?));
+            return Ok(Some(tokio::fs::read_to_string(entry.path()).await?));
         }
     }
 


### PR DESCRIPTION
Before, we were reading the README from the current working directory because of a couple things:

* We were reading `entry.file_name()` instead of `entry.path()`, which would be something like `README.md`, instead of a full path to the file. This would lead to reading the `README.md` (if it existed) from the current directory rather than the directory we just searched through.

* We were using the `flake_root` (the root of the git repository) to find the README. This would mean that we would read the `README.md` from wherever this git root was, rather than from the flake itself. Now, we read it from the flake's store path.