### PR TITLE
Don't re-append the subdir to the store path

### DIFF
--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,8 +1,5 @@
 use color_eyre::eyre::{eyre, WrapErr};
-use std::{
-    collections::HashSet,
-    path::Path,
-};
+use std::{collections::HashSet, path::Path};
 
 use crate::{
     graphql::{GithubGraphqlDataResult, MAX_LABEL_LENGTH, MAX_NUM_TOTAL_LABELS},

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,7 +1,7 @@
 use color_eyre::eyre::{eyre, WrapErr};
 use std::{
     collections::HashSet,
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use crate::{
@@ -140,8 +140,7 @@ impl ReleaseMetadata {
             None
         };
 
-        let readme_dir = flake_store_path.join(subdir);
-        let readme = get_readme(readme_dir).await?;
+        let readme = get_readme(flake_store_path).await?;
 
         let spdx_identifier = if spdx_expression.is_some() {
             spdx_expression
@@ -227,7 +226,7 @@ where
     }
 }
 
-async fn get_readme(readme_dir: PathBuf) -> color_eyre::Result<Option<String>> {
+async fn get_readme(readme_dir: &Path) -> color_eyre::Result<Option<String>> {
     let mut read_dir = tokio::fs::read_dir(readme_dir).await?;
 
     while let Some(entry) = read_dir.next_entry().await? {


### PR DESCRIPTION
In #81, we inadvertently appended the subdir to the path which already included the subdir when reading the readme. This causes publishing failures because the directory we expect the readme to exist in likely does not exist:

```
 INFO flakehub_push:push_new_release: Preparing release of grahamc/nix-starter-flakes/0.0.0 repository=grahamc/nix-starter-flakes mirror=false upload_name=grahamc/nix-starter-flakes
flake_store_path: "/nix/store/abg459275ipf6x32an2padhjjclx26ip-source/go"
readme_path: "/nix/store/abg459275ipf6x32an2padhjjclx26ip-source/go/go"
```