### PR TITLE
Set content type header

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -727,6 +727,10 @@ async fn push_new_release(
                 reqwest::header::HeaderName::from_static("x-amz-checksum-sha256"),
                 reqwest::header::HeaderValue::from_str(&flake_tarball_hash_base64).unwrap(),
             );
+            header_map.insert(
+                reqwest::header::CONTENT_TYPE,
+                reqwest::header::HeaderValue::from_str("application/gzip").unwrap(),
+            );
             header_map
         })
         .body(flake_tarball)


### PR DESCRIPTION
This sets the content type header so that `nix flake show "http://localhost:8080/f/DeterminateSystems/nix-installer/0.12.0-rc5.html"` and the like can work.

I tested and this is safe to merge as is, without changing the presign URL.