### PR TITLE
JWT: correct the audience

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -794,7 +794,7 @@ jobs:
     let actions_id_token_client = build_http_client().build()?;
     let response = actions_id_token_client
         .get(format!(
-            "{actions_id_token_request_url}&audience=api://AzureADTokenExchange"
+            "{actions_id_token_request_url}&audience=api.flakehub.com"
         ))
         .bearer_auth(actions_id_token_request_token)
         .send()


### PR DESCRIPTION
Previously, we were issuing a JWT scoped to a service, since we got inspiration from the magic nix cache. Oops! This fixes the audience to be flakehub specific.