### PR TITLE
Register flake output paths with FlakeHub

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -75,6 +75,9 @@ inputs:
     description: Whether to error if a release for the same version has already been uploaded.
     required: false
     default: false
+  include-output-paths:
+    description: Whether to register the output paths of each flake output with FlakeHub.
+    required: false
 
   flakehub-push-binary:
     description: Run a version of the `flakehub-push` binary from somewhere already on disk. Conflicts with all other `flakehub-push-*` options.
@@ -93,9 +96,6 @@ inputs:
     required: false
   flakehub-push-url:
     description: A URL pointing to a `flakehub-push` binary. Overrides all other `flakehub-push-*` options.
-    required: false
-  include-output-paths:
-    description: Whether to register the output paths of each flake output with FlakeHub.
     required: false
 
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-docker-container-actions

--- a/action.yaml
+++ b/action.yaml
@@ -94,6 +94,9 @@ inputs:
   flakehub-push-url:
     description: A URL pointing to a `flakehub-push` binary. Overrides all other `flakehub-push-*` options.
     required: false
+  include-output-paths:
+    description: Whether to register the output paths of each flake output with FlakeHub.
+    required: false
 
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-docker-container-actions
 runs:
@@ -119,6 +122,7 @@ runs:
       FLAKEHUB_PUSH_EXTRA_TAGS: ${{ inputs.extra-tags }}
       FLAKEHUB_PUSH_SPDX_EXPRESSION: ${{ inputs.spdx-expression }}
       FLAKEHUB_PUSH_ERROR_ON_CONFLICT: ${{ inputs.error-on-conflict }}
+      FLAKEHUB_PUSH_INCLUDE_OUTPUT_PATHS: ${{ inputs.include-output-paths }}
       # Also GITHUB_REPOSITORY, GITHUB_REF_NAME, GITHUB_TOKEN, ACTIONS_ID_TOKEN_REQUEST_TOKEN, ACTIONS_ID_TOKEN_REQUEST_URL
     run: |
       if [ "${RUNNER_OS}" == "Linux" ]; then

--- a/src/flake_info.rs
+++ b/src/flake_info.rs
@@ -147,7 +147,7 @@ pub(crate) async fn get_flake_outputs(
             &flake_url.escape_default().to_string(),
         )
         .replace(
-            "@INCLUDE_OUTPUT_PATHS@",
+            "INCLUDE_OUTPUT_PATHS",
             if include_output_paths {
                 "true"
             } else {

--- a/src/mixed-flake.nix
+++ b/src/mixed-flake.nix
@@ -2,7 +2,7 @@
   inputs.flake.url = "c9026fc0-ced9-48e0-aa3c-fc86c4c86df1";
   outputs = inputs:
     {
-      includeOutputPaths = @INCLUDE_OUTPUT_PATHS@;
+      includeOutputPaths = INCLUDE_OUTPUT_PATHS;
 
       contents =
         let
@@ -81,19 +81,23 @@
                                   outputs =
                                     if attrs ? derivation
                                     then
-                                      builtins.listToAttrs (
-                                        builtins.map (outputName:
-                                          {
-                                            name = outputName;
-                                            value = attrs.derivation.${outputName}.outPath;
-                                          }
-                                        ) attrs.derivation.outputs
-                                      )
+                                      builtins.listToAttrs
+                                        (
+                                          builtins.map
+                                            (outputName:
+                                              {
+                                                name = outputName;
+                                                value = attrs.derivation.${outputName}.outPath;
+                                              }
+                                            )
+                                            attrs.derivation.outputs
+                                        )
                                     else
                                       null;
                                 }
                               else
-                                { })
+                                { }
+                            )
                         else
                           { };
                     in

--- a/src/mixed-flake.nix
+++ b/src/mixed-flake.nix
@@ -68,6 +68,23 @@
                               forSystems = attrs.forSystems or null;
                               shortDescription = attrs.shortDescription or null;
                               what = attrs.what or null;
+                              derivation =
+                                if attrs ? derivation
+                                then builtins.unsafeDiscardStringContext attrs.derivation.drvPath
+                                else null;
+                              outputs =
+                                if attrs ? derivation
+                                then
+                                  builtins.listToAttrs (
+                                    builtins.map (outputName:
+                                      {
+                                        name = outputName;
+                                        value = attrs.derivation.${outputName}.outPath;
+                                      }
+                                    ) attrs.derivation.outputs
+                                  )
+                                else
+                                  null;
                               #evalChecks = attrs.evalChecks or {};
                             }
                         else

--- a/src/mixed-flake.nix
+++ b/src/mixed-flake.nix
@@ -2,6 +2,8 @@
   inputs.flake.url = "c9026fc0-ced9-48e0-aa3c-fc86c4c86df1";
   outputs = inputs:
     {
+      includeOutputPaths = @INCLUDE_OUTPUT_PATHS@;
+
       contents =
         let
           getFlakeOutputs = flake:
@@ -68,25 +70,30 @@
                               forSystems = attrs.forSystems or null;
                               shortDescription = attrs.shortDescription or null;
                               what = attrs.what or null;
-                              derivation =
-                                if attrs ? derivation
-                                then builtins.unsafeDiscardStringContext attrs.derivation.drvPath
-                                else null;
-                              outputs =
-                                if attrs ? derivation
-                                then
-                                  builtins.listToAttrs (
-                                    builtins.map (outputName:
-                                      {
-                                        name = outputName;
-                                        value = attrs.derivation.${outputName}.outPath;
-                                      }
-                                    ) attrs.derivation.outputs
-                                  )
-                                else
-                                  null;
                               #evalChecks = attrs.evalChecks or {};
-                            }
+                            } // (
+                              if inputs.self.includeOutputPaths then
+                                {
+                                  derivation =
+                                    if attrs ? derivation
+                                    then builtins.unsafeDiscardStringContext attrs.derivation.drvPath
+                                    else null;
+                                  outputs =
+                                    if attrs ? derivation
+                                    then
+                                      builtins.listToAttrs (
+                                        builtins.map (outputName:
+                                          {
+                                            name = outputName;
+                                            value = attrs.derivation.${outputName}.outPath;
+                                          }
+                                        ) attrs.derivation.outputs
+                                      )
+                                    else
+                                      null;
+                                }
+                              else
+                                { })
                         else
                           { };
                     in


### PR DESCRIPTION
This is disabled by default because 1) it might fail (e.g. if the flake uses IFD); and 2) it may be slower (since it requires evaluating the drvPath/outPaths of every flake output).