### PR TITLE
Offer an improved error experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -519,6 +519,7 @@ dependencies = [
  "spdx",
  "tar",
  "tempfile",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-error",
@@ -595,7 +596,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1877,9 +1878,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -1896,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2229,7 +2230,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2363,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2418,22 +2419,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2520,7 +2521,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2584,7 +2585,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2798,7 +2799,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2832,7 +2833,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3076,5 +3077,5 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ github-actions-oidc-claims = "0.3.0"
 spdx = "0.10.2"
 uuid = { version = "1.4.0", features = ["serde", "v7", "rand", "std"] }
 semver = { version = "1.0.18", features = ["serde"] }
+thiserror = "1.0.56"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/src/cli/instrumentation.rs
+++ b/src/cli/instrumentation.rs
@@ -136,7 +136,7 @@ impl<'a> Instrumentation {
                         _ => return Err(e).wrap_err_with(|| "parsing RUST_LOG directives"),
                     }
                 }
-                EnvFilter::try_new(&format!(
+                EnvFilter::try_new(format!(
                     "{}={}",
                     env!("CARGO_PKG_NAME").replace('-', "_"),
                     self.log_level()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,10 +11,7 @@ use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 use crate::{
-    flake_info::{check_flake_evaluates, get_flake_metadata, get_flake_outputs, get_flake_tarball},
-    graphql::{GithubGraphqlDataQuery, GithubGraphqlDataResult},
-    release_metadata::{ReleaseMetadata, RevisionInfo},
-    Visibility,
+    error::Error, flake_info::{check_flake_evaluates, get_flake_metadata, get_flake_outputs, get_flake_tarball}, graphql::{GithubGraphqlDataQuery, GithubGraphqlDataResult}, release_metadata::{ReleaseMetadata, RevisionInfo}, Visibility
 };
 
 const DEFAULT_ROLLING_PREFIX: &str = "0.1";
@@ -714,26 +711,33 @@ async fn push_new_release(
         "Got release metadata POST response"
     );
 
-    if release_metadata_post_response_status != StatusCode::OK {
-        if release_metadata_post_response_status == StatusCode::CONFLICT {
+    match release_metadata_post_response_status {
+        StatusCode::OK => (),
+        StatusCode::CONFLICT => {
             tracing::info!(
                 "Release for revision `{revision}` of {upload_name}/{rolling_prefix_or_tag} already exists; flakehub-push will not upload it again",
                 revision = release_metadata.revision
             );
             if error_if_release_conflicts {
-                return Err(color_eyre::eyre::eyre!(
-                    "{upload_name}/{rolling_prefix_or_tag} already exists"
-                ));
+                return Err(Error::Conflict { upload_name, rolling_prefix_or_tag })?;
             } else {
                 return Ok(());
             }
-        } else {
+        },
+        StatusCode::UNAUTHORIZED => {
+            let body = &release_metadata_post_response.bytes().await?;
+            let message = serde_json::from_slice::<String>(body)?;
+            return Err(Error::Unauthorized(message.into()))?;
+        },
+        _ => {
+            let body = &release_metadata_post_response.bytes().await?;
+            let message = serde_json::from_slice::<String>(body)?;
             return Err(eyre!(
                 "\
                 Status {release_metadata_post_response_status} from metadata POST\n\
                 {}\
             ",
-                String::from_utf8_lossy(&release_metadata_post_response.bytes().await.unwrap())
+                message
             ));
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,7 +11,11 @@ use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
 
 use crate::{
-    error::Error, flake_info::{check_flake_evaluates, get_flake_metadata, get_flake_outputs, get_flake_tarball}, graphql::{GithubGraphqlDataQuery, GithubGraphqlDataResult}, release_metadata::{ReleaseMetadata, RevisionInfo}, Visibility
+    error::Error,
+    flake_info::{check_flake_evaluates, get_flake_metadata, get_flake_outputs, get_flake_tarball},
+    graphql::{GithubGraphqlDataQuery, GithubGraphqlDataResult},
+    release_metadata::{ReleaseMetadata, RevisionInfo},
+    Visibility,
 };
 
 const DEFAULT_ROLLING_PREFIX: &str = "0.1";
@@ -719,16 +723,19 @@ async fn push_new_release(
                 revision = release_metadata.revision
             );
             if error_if_release_conflicts {
-                return Err(Error::Conflict { upload_name, rolling_prefix_or_tag })?;
+                return Err(Error::Conflict {
+                    upload_name,
+                    rolling_prefix_or_tag,
+                })?;
             } else {
                 return Ok(());
             }
-        },
+        }
         StatusCode::UNAUTHORIZED => {
             let body = &release_metadata_post_response.bytes().await?;
             let message = serde_json::from_slice::<String>(body)?;
-            return Err(Error::Unauthorized(message.into()))?;
-        },
+            return Err(Error::Unauthorized(message))?;
+        }
         _ => {
             let body = &release_metadata_post_response.bytes().await?;
             let message = serde_json::from_slice::<String>(body)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
     #[error("Unauthorized: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,19 @@
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+    #[error("{upload_name}/{rolling_prefix_or_tag} already exists")]
+    Conflict {
+        upload_name: String,
+        rolling_prefix_or_tag: String,
+    },
+}
+
+impl Error {
+    pub(crate) fn should_suggest_issue(&self) -> bool {
+        match self {
+            Self::Unauthorized(_) | Self::Conflict { .. } => false,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,10 @@ use std::{fmt::Display, io::IsTerminal};
 use clap::Parser;
 use error::Error;
 mod cli;
+mod error;
 mod flake_info;
 mod graphql;
 mod release_metadata;
-mod error;
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<std::process::ExitCode> {
@@ -20,16 +20,14 @@ async fn main() -> color_eyre::Result<std::process::ExitCode> {
         } else {
             color_eyre::config::Theme::dark()
         })
-        .issue_filter(|kind| {
-            match kind {
-                color_eyre::ErrorKind::NonRecoverable(_) => true,
-                color_eyre::ErrorKind::Recoverable(error) => {
-                    if let Some(known_error) = error.downcast_ref::<Error>() {
-                        known_error.should_suggest_issue()
-                    } else {
-                        true
-                    }
-                },
+        .issue_filter(|kind| match kind {
+            color_eyre::ErrorKind::NonRecoverable(_) => true,
+            color_eyre::ErrorKind::Recoverable(error) => {
+                if let Some(known_error) = error.downcast_ref::<Error>() {
+                    known_error.should_suggest_issue()
+                } else {
+                    true
+                }
             }
         })
         .install()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use std::{fmt::Display, io::IsTerminal};
 
 use clap::Parser;
+use error::Error;
 mod cli;
 mod flake_info;
 mod graphql;
 mod release_metadata;
+mod error;
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<std::process::ExitCode> {
@@ -17,6 +19,18 @@ async fn main() -> color_eyre::Result<std::process::ExitCode> {
             color_eyre::config::Theme::new()
         } else {
             color_eyre::config::Theme::dark()
+        })
+        .issue_filter(|kind| {
+            match kind {
+                color_eyre::ErrorKind::NonRecoverable(_) => true,
+                color_eyre::ErrorKind::Recoverable(error) => {
+                    if let Some(known_error) = error.downcast_ref::<Error>() {
+                        known_error.should_suggest_issue()
+                    } else {
+                        true
+                    }
+                },
+            }
         })
         .install()?;
 


### PR DESCRIPTION
Skip showing the fancy issue report link if the user encounters a known, expected error. (Such as in the future when we stop creating users/orgs on push and invite them to register/login first).