### PR TITLE
Remove non-token dependencies on GitHub Actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -2709,6 +2710,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ spdx = "0.10.2"
 uuid = { version = "1.4.0", features = ["serde", "v7", "rand", "std"] }
 semver = { version = "1.0.18", features = ["serde"] }
 thiserror = "1.0.56"
+url = { version = "2.5.0", features = ["serde"] }
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -25,7 +25,7 @@ pub(crate) struct FlakeHubPushCli {
         env = "FLAKEHUB_PUSH_HOST",
         default_value = "https://api.flakehub.com"
     )]
-    pub(crate) host: String,
+    pub(crate) host: url::Url,
     #[clap(long, env = "FLAKEHUB_PUSH_VISIBLITY")]
     pub(crate) visibility: crate::Visibility,
     // Will also detect `GITHUB_REF_NAME`
@@ -279,7 +279,7 @@ impl FlakeHubPushCli {
         name = "flakehub_push"
         skip_all,
         fields(
-            host = self.host,
+            host = %self.host,
             visibility = ?self.visibility,
             name = self.name.0,
             tag = tracing::field::Empty,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -490,7 +490,7 @@ impl FlakeHubPushCli {
                 .collect::<HashSet<String>>();
 
             match jwt_issuer_uri.0 {
-                None => get_actions_id_bearer_token()
+                None => get_actions_id_bearer_token(&host)
                     .await
                     .wrap_err("Getting upload bearer token from GitHub")?,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -261,6 +261,7 @@ impl FlakeHubPushCli {
             directory = tracing::field::Empty,
             repository = tracing::field::Empty,
             git_root = tracing::field::Empty,
+            commit_count = tracing::field::Empty,
             mirror = self.mirror,
             jwt_issuer_uri = tracing::field::Empty,
             extra_labels = self.extra_labels.join(","),
@@ -458,6 +459,7 @@ impl FlakeHubPushCli {
         };
 
         let commit_count = github_graphql_data_result.rev_count;
+        span.record("commit_count", commit_count);
 
         let spdx_identifier = if spdx_expression.0.is_some() {
             spdx_expression.0

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -544,7 +544,7 @@ impl FlakeHubPushCli {
             .collect();
 
         let Some(commit_count) = commit_count else {
-            return Err(eyre!("Did not get `commit_count`"));
+            return Err(eyre!("Could not determine commit count, this is normally determined via the `--git-root` argument or via the GitHub API"));
         };
 
         push_new_release(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -457,15 +457,7 @@ impl FlakeHubPushCli {
             }
         };
 
-        let commit_count = match revision_info.local_revision_count {
-            Some(n) => n as i64,
-            None => {
-                tracing::debug!(
-                    "Getting revision count locally failed, using data from github instead"
-                );
-                github_graphql_data_result.rev_count
-            }
-        };
+        let commit_count = github_graphql_data_result.rev_count;
 
         let spdx_identifier = if spdx_expression.0.is_some() {
             spdx_expression.0

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -300,7 +300,8 @@ impl FlakeHubPushCli {
         let span = tracing::Span::current();
         tracing::trace!("Executing");
 
-        let is_github_actions = std::env::var("GITHUB_ACTION").ok().is_some();
+        let is_github_actions =
+            self.github_token.0.is_some() || std::env::var("GITHUB_ACTION").ok().is_some();
         if is_github_actions {
             tracing::debug!("Running inside Github Actions, enriching from environment");
             self.populate_missing_from_github()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -248,6 +248,7 @@ impl clap::builder::TypedValueParser for U64ToNoneParser {
 }
 
 impl FlakeHubPushCli {
+    #[tracing::instrument(skip_all)]
     pub(crate) fn populate_missing_from_github(&mut self) {
         if self.git_root.0.is_none() {
             let env_key = "GITHUB_WORKSPACE";

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -471,9 +471,13 @@ impl FlakeHubPushCli {
             } else {
                 // Provide the user notice if the SPDX expression passed differs from the one detected on GitHub -- It's probably something they care about.
                 if github_graphql_data_result.spdx_identifier
-                    != spdx_expression.map(|v| v.to_string())
+                    != spdx_expression.as_ref().map(|v| v.to_string())
                 {
-                    tracing::debug!("Inferred SPDX identifier from GitHub API was `{}` while `{}` was passed via argument", github_graphql_data_result.spdx_identifier.unwrap_or_else(|| "None".to_string()), spdx_expression.unwrap_or_else(|| "None".to_string()))
+                    tracing::debug!(
+                        "Inferred SPDX identifier from GitHub API was `{}` while `{}` was passed via argument",
+                        github_graphql_data_result.spdx_identifier.unwrap_or_else(|| "None".to_string()),
+                        spdx_expression.as_ref().map(|v| v.to_string()).unwrap_or_else(|| "None".to_string())
+                    )
                 }
                 spdx_expression
             };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -303,7 +303,7 @@ impl FlakeHubPushCli {
         let is_github_actions =
             self.github_token.0.is_some() || std::env::var("GITHUB_ACTION").ok().is_some();
         if is_github_actions {
-            tracing::debug!("Running inside Github Actions, enriching from environment");
+            tracing::debug!("Running inside Github Actions, will enrich with GitHub API data and push with authorized Github bearer token");
             self.populate_missing_from_github()
         }
 
@@ -473,10 +473,10 @@ impl FlakeHubPushCli {
                 if github_graphql_data_result.spdx_identifier
                     != spdx_expression.as_ref().map(|v| v.to_string())
                 {
-                    tracing::debug!(
-                        "Inferred SPDX identifier from GitHub API was `{}` while `{}` was passed via argument",
+                    tracing::warn!(
+                        "SPDX identifier `{}` was passed via argument, but GitHub's API suggests it may be `{}`",
+                        spdx_expression.as_ref().map(|v| v.to_string()).unwrap_or_else(|| "None".to_string()),
                         github_graphql_data_result.spdx_identifier.unwrap_or_else(|| "None".to_string()),
-                        spdx_expression.as_ref().map(|v| v.to_string()).unwrap_or_else(|| "None".to_string())
                     )
                 }
                 spdx_expression

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -7,7 +7,7 @@ use crate::build_http_client;
 #[tracing::instrument(skip_all, fields(audience = tracing::field::Empty))]
 pub(crate) async fn get_actions_id_bearer_token(host: &url::Url) -> color_eyre::Result<String> {
     let span = tracing::Span::current();
-    let audience = host.host_str().ok_or_else(|| eyre!("`host` must contain a valid host (eg `https://api.flakehub.com` contains `api.flakehub.com`)"))?;
+    let audience = host.host_str().ok_or_else(|| eyre!("`--host` must contain a valid host (eg `https://api.flakehub.com` contains `api.flakehub.com`)"))?;
     span.record("audience", audience);
 
     let actions_id_token_request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN")

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -4,8 +4,12 @@ use color_eyre::eyre::{eyre, WrapErr};
 
 use crate::build_http_client;
 
-#[tracing::instrument(skip_all)]
-pub(crate) async fn get_actions_id_bearer_token(audience: &str) -> color_eyre::Result<String> {
+#[tracing::instrument(skip_all, fields(audience = tracing::field::Empty))]
+pub(crate) async fn get_actions_id_bearer_token(host: &url::Url) -> color_eyre::Result<String> {
+    let span = tracing::Span::current();
+    let audience = host.host_str().ok_or_else(|| eyre!("`host` must contain a valid host (eg `https://api.flakehub.com` contains `api.flakehub.com`)"))?;
+    span.record("audience", audience);
+
     let actions_id_token_request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
         // We do want to preserve the whitespace here  
         .wrap_err("\

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -5,7 +5,7 @@ use color_eyre::eyre::{eyre, WrapErr};
 use crate::build_http_client;
 
 #[tracing::instrument(skip_all)]
-pub(crate) async fn get_actions_id_bearer_token() -> color_eyre::Result<String> {
+pub(crate) async fn get_actions_id_bearer_token(audience: &str) -> color_eyre::Result<String> {
     let actions_id_token_request_token = std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
         // We do want to preserve the whitespace here  
         .wrap_err("\
@@ -26,7 +26,7 @@ jobs:
     let actions_id_token_client = build_http_client().build()?;
     let response = actions_id_token_client
         .get(format!(
-            "{actions_id_token_request_url}&audience=api.flakehub.com"
+            "{actions_id_token_request_url}&audience={audience}"
         ))
         .bearer_auth(actions_id_token_request_token)
         .send()

--- a/src/push.rs
+++ b/src/push.rs
@@ -48,7 +48,7 @@ pub(crate) async fn push_new_release(
     flake_root: &Path,
     subdir: &Path,
     revision: String,
-    revision_count: i64,
+    revision_count: usize,
     upload_name: String,
     mirror: bool,
     visibility: Visibility,
@@ -59,8 +59,6 @@ pub(crate) async fn push_new_release(
     spdx_expression: Option<spdx::Expression>,
     error_if_release_conflicts: bool,
     include_output_paths: bool,
-    project_id: i64,
-    owner_id: i64,
 ) -> color_eyre::Result<()> {
     let span = tracing::Span::current();
     span.record("upload_name", tracing::field::display(upload_name.clone()));
@@ -224,8 +222,6 @@ pub(crate) async fn push_new_release(
         visibility,
         labels,
         spdx_expression,
-        project_id,
-        owner_id,
     )
     .await
     .wrap_err("Building release metadata")?;

--- a/src/push.rs
+++ b/src/push.rs
@@ -237,11 +237,9 @@ pub(crate) async fn push_new_release(
         rolling_prefix_or_tag.to_string() // This will always be the tag since `self.rolling_prefix` was empty.
     };
 
-    let release_metadata_post_url = format!(
-        "{host}/upload/{upload_name}/{rolling_minor_with_postfix_or_tag}/{flake_tarball_len}/{flake_tarball_hash_base64}"
-    );
+    let release_metadata_post_url = host.join(&format!("upload/{upload_name}/{rolling_minor_with_postfix_or_tag}/{flake_tarball_len}/{flake_tarball_hash_base64}"))?;
     tracing::debug!(
-        url = release_metadata_post_url,
+        url = %release_metadata_post_url,
         "Computed release metadata POST URL"
     );
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -20,7 +20,7 @@ const DEFAULT_ROLLING_PREFIX: &str = "0.1";
 #[tracing::instrument(
     skip_all,
     fields(
-        host,
+        %host,
         flake_root,
         subdir,
         revision,
@@ -43,7 +43,7 @@ const DEFAULT_ROLLING_PREFIX: &str = "0.1";
 )]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn push_new_release(
-    host: &str,
+    host: &url::Url,
     upload_bearer_token: &str,
     flake_root: &Path,
     subdir: &Path,

--- a/src/push.rs
+++ b/src/push.rs
@@ -353,8 +353,8 @@ pub(crate) async fn push_new_release(
     }
 
     // Make the release we just uploaded visible.
-    let publish_post_url = format!("{host}/publish/{}", release_metadata_post_result.uuid);
-    tracing::debug!(url = publish_post_url, "Computed publish POST URL");
+    let publish_post_url = host.join(&format!("publish/{}", release_metadata_post_result.uuid))?;
+    tracing::debug!(url = %publish_post_url, "Computed publish POST URL");
 
     let publish_response = flakehub_client
         .post(publish_post_url)

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,10 +1,7 @@
 use color_eyre::eyre::{eyre, WrapErr};
-use std::{collections::HashSet, path::Path};
+use std::path::Path;
 
-use crate::{
-    github::graphql::{GithubGraphqlDataResult, MAX_LABEL_LENGTH, MAX_NUM_TOTAL_LABELS},
-    Visibility,
-};
+use crate::Visibility;
 
 const README_FILENAME_LOWERCASE: &str = "readme.md";
 
@@ -90,92 +87,63 @@ impl ReleaseMetadata {
         subdir = %subdir.display(),
         description = tracing::field::Empty,
         readme_path = tracing::field::Empty,
-        revision = tracing::field::Empty,
-        revision_count = tracing::field::Empty,
-        commit_count = tracing::field::Empty,
+        %revision,
+        %commit_count,
         spdx_identifier = tracing::field::Empty,
         visibility = ?visibility,
+        %project_id,
+        %owner_id
     ))]
     pub(crate) async fn build(
         flake_store_path: &Path,
         subdir: &Path,
-        revision_info: RevisionInfo,
+        revision: String,
+        commit_count: i64,
         flake_metadata: serde_json::Value,
         flake_outputs: serde_json::Value,
         upload_name: String,
         mirror: bool,
         visibility: Visibility,
-        github_graphql_data_result: GithubGraphqlDataResult,
-        extra_labels: Vec<String>,
-        spdx_expression: Option<spdx::Expression>,
+        labels: Vec<String>,
+        spdx_identifier: Option<spdx::Expression>,
+        project_id: i64,
+        owner_id: i64,
     ) -> color_eyre::Result<ReleaseMetadata> {
         let span = tracing::Span::current();
 
-        span.record("revision_string", &revision_info.revision);
+        if let Some(spdx_identifier) = &spdx_identifier {
+            span.record("spdx_identifier", tracing::field::display(spdx_identifier));
+        }
 
         assert!(subdir.is_relative());
 
-        let revision_count = match revision_info.local_revision_count {
-            Some(n) => n as i64,
-            None => {
-                tracing::debug!(
-                    "Getting revision count locally failed, using data from github instead"
-                );
-                github_graphql_data_result.rev_count
-            }
-        };
-        span.record("revision_count", revision_count);
-
         let description = if let Some(description) = flake_metadata.get("description") {
-            Some(description
+            let description_value = description
                 .as_str()
                 .ok_or_else(|| {
                     eyre!("`nix flake metadata --json` does not have a string `description` field")
                 })?
-                .to_string())
+                .to_string();
+            span.record("description", tracing::field::display(&description_value));
+            Some(description_value)
         } else {
             None
         };
 
-        let readme = get_readme(flake_store_path).await?;
-
-        let spdx_identifier = if spdx_expression.is_some() {
-            spdx_expression
-        } else if let Some(spdx_string) = github_graphql_data_result.spdx_identifier {
-            let parsed = spdx::Expression::parse(&spdx_string)
-                .wrap_err("Invalid SPDX license identifier reported from the GitHub API, either you are using a non-standard license or GitHub has returned a value that cannot be validated")?;
-            span.record("spdx_identifier", tracing::field::display(&parsed));
-            Some(parsed)
-        } else {
-            None
-        };
+        let readme_path = get_readme(flake_store_path).await?;
+        if let Some(readme_path) = &readme_path {
+            span.record("readme_path", tracing::field::display(readme_path));
+        }
 
         tracing::trace!("Collected ReleaseMetadata information");
-
-        // Here we merge explicitly user-supplied labels and the labels ("topics")
-        // associated with the repo. Duplicates are excluded and all
-        // are converted to lower case.
-        let labels: Vec<String> = extra_labels
-            .into_iter()
-            .chain(github_graphql_data_result.topics.into_iter())
-            .collect::<HashSet<String>>()
-            .into_iter()
-            .take(MAX_NUM_TOTAL_LABELS)
-            .map(|s| s.trim().to_lowercase())
-            .filter(|t: &String| {
-                !t.is_empty()
-                    && t.len() <= MAX_LABEL_LENGTH
-                    && t.chars().all(|c| c.is_alphanumeric() || c == '-')
-            })
-            .collect();
 
         Ok(ReleaseMetadata {
             description,
             repo: upload_name.to_string(),
             raw_flake_metadata: flake_metadata.clone(),
-            readme,
-            revision: revision_info.revision,
-            commit_count: github_graphql_data_result.rev_count,
+            readme: readme_path,
+            revision,
+            commit_count,
             visibility,
             outputs: flake_outputs,
             source_subdirectory: Some(
@@ -186,8 +154,8 @@ impl ReleaseMetadata {
             ),
             mirrored: mirror,
             spdx_identifier,
-            project_id: github_graphql_data_result.project_id,
-            owner_id: github_graphql_data_result.owner_id,
+            project_id,
+            owner_id,
             labels,
         })
     }

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -84,7 +84,7 @@ impl ReleaseMetadata {
         flake_store_path = %flake_store_path.display(),
         subdir = %subdir.display(),
         description = tracing::field::Empty,
-        readme_path = tracing::field::Empty,
+        readme = tracing::field::Empty,
         %revision,
         %commit_count,
         spdx_identifier = tracing::field::Empty,
@@ -124,9 +124,12 @@ impl ReleaseMetadata {
             None
         };
 
-        let readme_path = get_readme(flake_store_path).await?;
-        if let Some(readme_path) = &readme_path {
-            span.record("readme_path", tracing::field::display(readme_path));
+        let readme = get_readme(flake_store_path).await?;
+        if readme.is_some() {
+            span.record(
+                "readme",
+                tracing::field::display(flake_store_path.join("README.md").display()),
+            );
         }
 
         tracing::trace!("Collected ReleaseMetadata information");
@@ -135,7 +138,7 @@ impl ReleaseMetadata {
             description,
             repo: upload_name.to_string(),
             raw_flake_metadata: flake_metadata.clone(),
-            readme: readme_path,
+            readme,
             revision,
             commit_count,
             visibility,


### PR DESCRIPTION
This does quite a bit of logic changing to make us not require GitHub Actions for anything but the bearer token.

It is important to note that this (for now) refuses to run if `GITHUB_ACTION` is not set or `--github-token` is not passed. So this doesn't actually remove the need for Github Actions, it just sets the stage for us to add support (similar to #107 and #108).

I believe some of the error messages are still a bit rough... Should give them a better pass before merge.