### PR TITLE
Decouple `--github-token` and `is_github_actions` logic

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -435,7 +435,7 @@ impl FlakeHubPushCli {
             // Take the opportunity to be able to populate/encrich data from the GitHub API since we need it for project/owner_id anywys
             let github_graphql_data_result = GithubGraphqlDataQuery::get(
                 &github_api_client,
-                &github_token,
+                github_token,
                 &project_owner,
                 &project_name,
                 &revision,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -303,7 +303,7 @@ impl FlakeHubPushCli {
 
         let is_github_actions = std::env::var("GITHUB_ACTION").ok().is_some();
         if is_github_actions {
-            tracing::debug!("Running inside Github Actions, enrich arguments with GitHub Actions environment data");
+            tracing::debug!("Running inside Github Actions, enriching arguments with GitHub Actions environment data");
             self.populate_from_github_actions_environment()
         }
 


### PR DESCRIPTION
Furthers #109 to decouple the `--github-token` and `is_github_actions` logic. This should make it quite easy to add support for running in other contexts once FlakeHub itself supports those.