### PR TITLE
fake_auth: fix fakeidp jwt usage, take Url for issuer

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -39,11 +39,9 @@ pub(crate) struct FlakeHubPushCli {
     // This should only be used by DeterminateSystems
     #[clap(long, env = "FLAKEHUB_PUSH_MIRROR", default_value_t = false)]
     pub(crate) mirror: bool,
-    /// URL of a JWT mock server (like https://github.com/ruiyang/jwt-mock-server) which can issue tokens.
-    ///
-    /// Used instead of ACTIONS_ID_TOKEN_REQUEST_URL/ACTIONS_ID_TOKEN_REQUEST_TOKEN when developing locally.
-    #[clap(long, env = "FLAKEHUB_PUSH_JWT_ISSUER_URI", value_parser = StringToNoneParser, default_value = "")]
-    pub(crate) jwt_issuer_uri: OptionString,
+
+    /// URL of a JWT mock server (like https://github.com/spectare/fakeidp) which can issue tokens.
+    pub(crate) jwt_issuer_uri: Option<url::Url>,
 
     /// User-supplied labels, merged with any associated with GitHub repository (if possible)
     #[clap(

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -198,7 +198,7 @@ impl PushContext {
 
         // "cli" and "git_ctx" are the user/env supplied info, augmented with data we might have fetched from github/gitlab apis
 
-        let (token, git_ctx) = match (is_github, is_gitlab, &cli.jwt_issuer_uri.0) {
+        let (token, git_ctx) = match (is_github, is_gitlab, &cli.jwt_issuer_uri) {
             (true, false, None) => {
                 // GITHUB CI
                 let github_token = cli


### PR DESCRIPTION
Update for changes for internal flakehub testing.

I dropped the env var / special handling. We really shouldn't be allowing this to be overriden in actions (and in fact, we already don't have a action-variable for it).

Leaving as draft, it targets the refactor branch and should co-merge with the backend change.