### PR TITLE
Fix macOS build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: DeterminateSystems/flake-checker-action@main
+
       - uses: DeterminateSystems/nix-installer-action@main
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
-
-      - uses: DeterminateSystems/flake-checker-action@main
 
       - name: "Nix formatting"
         run: git ls-files '*.nix' | nix develop --command xargs nixpkgs-fmt --check
@@ -32,7 +32,7 @@ jobs:
         run: nix develop --command cargo clippy --all-targets --all-features --  -Dwarnings
 
       - name: "Nix Flake Check"
-        run: nix flake check --print-build-logs
+        run: nix flake check --all-systems --print-build-logs
 
       - name: Build package
         run: "nix build .# -L --fallback"
@@ -44,3 +44,23 @@ jobs:
           name: flakehub-push-X64-Linux
           path: result/bin/flakehub-push
           retention-days: 1
+
+  # For local development purposes
+  build-artifacts-macos:
+    runs-on: ${{ matrix.systems.runner }}
+    strategy:
+      matrix:
+        systems:
+          - nix-system: aarch64-darwin
+            runner: macos-latest-xlarge
+          - nix-system: x86_64-darwin
+            runner: macos-12
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build package
+        run: "nix build .# -L --fallback"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /dist
 /src
 pnpm-lock.yaml
+flake.lock

--- a/flake.lock
+++ b/flake.lock
@@ -4,7 +4,9 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": ["nixpkgs"],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay"
       },
       "locked": {
@@ -18,6 +20,26 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/ipetkov/crane/0.14.1.tar.gz"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1717223092,
+        "narHash": "sha256-ih8NPk3Jn5EAILOGQZ+KS5NLmu6QmwohJX+36MaTAQE=",
+        "rev": "9a025daf6799e3af80b677f0af57ef76432c3fcf",
+        "revCount": 1885,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.1885%2Brev-9a025daf6799e3af80b677f0af57ef76432c3fcf/018fd2dd-a26f-7826-b82f-785503111a87/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/nix-community/fenix/0.1.1885.tar.gz"
       }
     },
     "flake-compat": {
@@ -54,24 +76,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1711703276,
@@ -89,14 +93,37 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay_2"
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717169693,
+        "narHash": "sha256-qBruki5NHrSqIw5ulxtwFmVsb6W/aOKOMjsCJjfalA4=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "d6d735e6f20ef78b16a79886fe28bd69cf059504",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": ["crane", "flake-utils"],
-        "nixpkgs": ["crane", "nixpkgs"]
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1696299134,
@@ -112,41 +139,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": ["nixpkgs"]
-      },
-      "locked": {
-        "lastModified": 1711937855,
-        "narHash": "sha256-jlfDBRtsLoqRNFxtQtG47wsrwVsQSV4AqoMgWG6Bvng=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "3f46a51b47f56c24b4d7e8db8fb8e73118923f96",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
       url = "https://flakehub.com/f/ipetkov/crane/0.14.1.tar.gz";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
+    fenix = {
+      url = "https://flakehub.com/f/nix-community/fenix/0.1.1885.tar.gz";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -24,42 +24,50 @@
         inherit system;
         pkgs = import inputs.nixpkgs {
           inherit system;
-          overlays = [
-            inputs.self.overlays.default
-            inputs.rust-overlay.overlays.default
-          ];
+          overlays = [ inputs.self.overlays.default ];
         };
-        lib = pkgs.lib;
       });
     in
     {
-      overlays.default = final: prev: {
+      overlays.default = final: prev: rec {
+        system = final.stdenv.hostPlatform.system;
+
+        rustToolchain = with inputs.fenix.packages.${system};
+          combine ([
+            stable.clippy
+            stable.rustc
+            stable.cargo
+            stable.rustfmt
+            stable.rust-src
+          ] ++ final.lib.optionals (system == "x86_64-linux") [
+            targets.x86_64-unknown-linux-musl.stable.rust-std
+          ] ++ final.lib.optionals (system == "aarch64-linux") [
+            targets.aarch64-unknown-linux-musl.stable.rust-std
+          ]);
+
+        craneLib = (inputs.crane.mkLib final).overrideToolchain rustToolchain;
+
         flakehub-push = inputs.self.packages.${final.stdenv.system}.flakehub-push;
       };
 
-      packages = forAllSystems ({ system, pkgs, lib, ... }:
-        let
-          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
-          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-            targets = [ "x86_64-unknown-linux-musl" ];
-          };
-        in
-        rec {
-          default = flakehub-push;
+      packages = forAllSystems ({ system, pkgs, ... }: rec {
+        default = flakehub-push;
 
-          flakehub-push = craneLib.buildPackage {
+        flakehub-push = pkgs.craneLib.buildPackage
+          {
             pname = "flakehub-push";
             version = "0.1.0";
-            src = craneLib.path ./.;
+            src = pkgs.craneLib.path ./.;
 
-            CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
-            CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-
-            buildInputs = lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [
+            buildInputs = pkgs.lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [
+              libiconv
               darwin.apple_sdk.frameworks.SystemConfiguration
             ]);
-          };
-        });
+          } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+          CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+        };
+      });
 
       devShells = forAllSystems ({ system, pkgs, ... }: {
         default = pkgs.mkShell {


### PR DESCRIPTION
This PR fixes the macOS builds for `flakehub-push` and also switches out `rust-overlay` in favor of Fenix (mostly just to bring it in line with our other Rust-y flakes).