### PR TITLE
Enable auto-formatting subgroups in flake names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.rs]
+indent_size = 4

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -112,8 +112,12 @@ pub(crate) struct FlakeHubPushCli {
     // Gitlab has a concept of subgroups, which enables repo names like https://gitlab.com/a/b/c/d/e/f/g. By default,
     // flakehub-push would parse that to flake name `a/b-c-d-e-f-g`. This flag/environment variable provides a
     // mechanism to disable this behavior.
-    #[clap(long, env = "FLAKEHUB_PUSH_DISABLE_SUBGROUPS", default_value_t = false)]
-    pub(crate) disable_subgroups: bool,
+    #[clap(
+        long,
+        env = "FLAKEHUB_PUSH_DISABLE_RENAME_SUBGROUPS",
+        default_value_t = true
+    )]
+    pub(crate) disable_rename_subgroups: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -108,6 +108,12 @@ pub(crate) struct FlakeHubPushCli {
 
     #[clap(long, env = "FLAKEHUB_PUSH_INCLUDE_OUTPUT_PATHS", value_parser = EmptyBoolParser, default_value_t = false)]
     pub(crate) include_output_paths: bool,
+
+    // Gitlab has a concept of subgroups, which enables repo names like https://gitlab.com/a/b/c/d/e/f/g. By default,
+    // flakehub-push would parse that to flake name `a/b-c-d-e-f-g`. This flag/environment variable provides a
+    // mechanism to disable this behavior.
+    #[clap(long, env = "FLAKEHUB_PUSH_DISABLE_SUBGROUPS", default_value_t = false)]
+    pub(crate) disable_subgroups: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -424,30 +424,6 @@ fn get_project_owner_and_name(
         }
         _ => Err(eyre!(error_msg)),
     }
-
-    /*
-    match (
-        repository_split.next(),
-        repository_split.next(),
-        repository_split.next(),
-    ) {
-        (Some(owner), Some(subgroup), Some(name)) if subgroups_enabled => {
-            // Gitlab subgroups can be nested quite deeply. This logic supports any level of nesting
-            // by appending `-{segment}` for each additional segment.
-            let name_from_segments =
-                repository_split.fold(String::from(name), |mut acc, segment| {
-                    acc.push_str(&format!("-{segment}"));
-                    acc
-                });
-            Ok((
-                String::from(owner),
-                format!("{}-{}", subgroup, name_from_segments),
-            ))
-        }
-        (Some(owner), Some(name), None) => Ok((String::from(owner), String::from(name))),
-        _ => Err(eyre!(error_msg)),
-    }
-    */
 }
 
 #[cfg(test)]

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -105,7 +105,7 @@ impl PushContext {
         };
 
         let (project_owner, project_name) =
-            get_project_owner_and_name(repository, exec_env.clone(), cli.disable_subgroups)?;
+            get_project_owner_and_name(repository, exec_env.clone(), cli.disable_rename_subgroups)?;
 
         let maybe_git_root = match &cli.git_root.0 {
             Some(gr) => Ok(gr.to_owned()),
@@ -389,10 +389,10 @@ impl PushContext {
 fn get_project_owner_and_name(
     repository: &str,
     exec_env: ExecutionEnvironment,
-    subgroups_explicitly_disabled: bool,
+    renaming_subgroups_explicitly_disabled: bool,
 ) -> Result<(String, String)> {
     let subgroups_enabled =
-        !subgroups_explicitly_disabled && matches!(exec_env, ExecutionEnvironment::GitLab);
+        !renaming_subgroups_explicitly_disabled && matches!(exec_env, ExecutionEnvironment::GitLab);
 
     let mut repository_split = repository.split('/');
 

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -409,18 +409,17 @@ fn get_project_owner_and_name(
         (Some(owner), Some(subgroup), Some(name))
             if matches!(exec_env, ExecutionEnvironment::GitLab) =>
         {
-            Ok((String::from(owner), {
-                // Gitlab subgroups can be nested quite deeply. This logic supports any level of nesting
-                // by appending `-{segment}` for each additional segment.
-                let mut s = String::from(subgroup);
-                s.push('-');
-                s.push_str(name);
-                for segment in repository_split {
-                    s.push('-');
-                    s.push_str(segment);
-                }
-                s
-            }))
+            // Gitlab subgroups can be nested quite deeply. This logic supports any level of nesting
+            // by appending `-{segment}` for each additional segment.
+            let name_from_segments =
+                repository_split.fold(String::from(name), |mut acc, segment| {
+                    acc.push_str(&format!("-{segment}"));
+                    acc
+                });
+            Ok((
+                String::from(owner),
+                format!("{}-{}", subgroup, name_from_segments),
+            ))
         }
         (Some(owner), Some(name), None) => Ok((String::from(owner), String::from(name))),
         _ => Err(eyre!(error_msg)),

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -415,7 +415,7 @@ fn get_project_owner_and_name(
                 let mut s = String::from(subgroup);
                 s.push('-');
                 s.push_str(name);
-                while let Some(segment) = repository_split.next() {
+                for segment in repository_split {
                     s.push('-');
                     s.push_str(segment);
                 }

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -387,7 +387,7 @@ impl PushContext {
 }
 
 fn get_project_owner_and_name(
-    repository: &String,
+    repository: &str,
     exec_env: ExecutionEnvironment,
 ) -> Result<(String, String)> {
     let mut repository_split = repository.split('/');

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -407,21 +407,19 @@ fn get_project_owner_and_name(
     };
 
     match (repository_split.next(), repository_split.next()) {
-        (Some(owner), Some(name)) => {
+        (Some(owner), Some(name)) => Ok((
+            String::from(owner),
+            // If subgroup renaming is enabled, all segments past the first are treated
+            // equally and joined by dashes
             if subgroup_renaming_enabled {
-                Ok((
-                    String::from(owner),
-                    // If subgroup renaming is enabled, all segments past the first are treated
-                    // equally and joined by dashes
-                    repository_split.fold(String::from(name), |mut acc, segment| {
-                        acc.push_str(&format!("-{segment}"));
-                        acc
-                    }),
-                ))
+                repository_split.fold(String::from(name), |mut acc, segment| {
+                    acc.push_str(&format!("-{segment}"));
+                    acc
+                })
             } else {
-                Ok((String::from(owner), String::from(name)))
-            }
-        }
+                String::from(name)
+            },
+        )),
         _ => Err(eyre!(error_msg)),
     }
 }

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -415,6 +415,10 @@ fn determine_names(
     if subgroup_renaming_explicitly_disabled && repository_split.next().is_some() {
         Err(eyre!(error_msg))?;
     }
+    // If subgroup renaming is disabled, the project name is just the originally provided
+    // name (and we've already determined that the name is of the form `{owner}/{project}`.
+    // But if subgroup renaming is disabled, then a repo name like `a/b/c/d/e` is converted
+    // to `a/b-c-d-e`.
     let project_name = if subgroup_renaming_explicitly_disabled {
         project_name
     } else {

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -393,8 +393,8 @@ fn get_project_owner_and_name(
     let mut repository_split = repository.split('/');
 
     Ok(match repository_split.clone().count() {
-        // Gitlab supports subgroups (repos of the form `org/subgroup/repo`). In that environment, we
-        // automatically "flatten" this to `org/subgroup-repo`
+        // Gitlab supports subgroups (repos of the form `owner/subgroup/repo`). In that environment, we
+        // automatically "flatten" this to `owner/subgroup-repo`
         3 => match exec_env {
             ExecutionEnvironment::GitLab => (
                 String::from(


### PR DESCRIPTION
Gitlab supports subgroups that can nested up to 20 levels, which doesn't work well without our `{owner}/{repo}` schema for flakes. This PR handles subgroup names by converting all slashes past the first one into dashes. Some example conversions:

```ruby
"a/b" => "a/b"
"a/b/c" => "a/b-c"
"a/b/c/d" => "a/b-c-d"
"a/b/c/d/e/f/g/h/i/j/k" => "a/b-c-d-e-f-g-h-i-j-k"
```

There's also a built-in escape hatch from this behavior via `FLAKEHUB_PUSH_DISABLE_SUBGROUPS` or `--disable-subgroups`.