### PR TITLE
Handle non-existent response body

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,12 +8,14 @@ pub(crate) enum Error {
         upload_name: String,
         release_version: String,
     },
+    #[error("Bad request: {0}")]
+    BadRequest(String),
 }
 
 impl Error {
     pub(crate) fn should_suggest_issue(&self) -> bool {
         match self {
-            Self::Unauthorized(_) | Self::Conflict { .. } => false,
+            Self::Unauthorized(_) | Self::Conflict { .. } | Self::BadRequest(_) => false,
         }
     }
 
@@ -26,6 +28,7 @@ impl Error {
                     println!("::error title=Unauthorized::{message}")
                 }
                 Error::Conflict { .. } => println!("::error title=Conflict::{self}"),
+                Error::BadRequest(_) => println!("::error title=BadRequest::{self}"),
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,9 +122,12 @@ async fn execute() -> Result<std::process::ExitCode> {
                 }
                 StatusCode::BAD_REQUEST => {
                     let body = response.bytes().await?;
-                    let message = serde_json::from_slice::<String>(&body)?;
-
-                    return Err(Error::BadRequest(message))?;
+                    let message = serde_json::from_slice::<String>(&body).ok();
+                    return Err(Error::BadRequest(if let Some(message) = message {
+                        message
+                    } else {
+                        String::from("no body")
+                    }))?;
                 }
                 _ => {
                     let body = response.bytes().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,13 +116,10 @@ async fn execute() -> Result<std::process::ExitCode> {
                     }
                 }
                 StatusCode::UNAUTHORIZED => {
-                    let body = response.bytes().await?;
-                    let message = serde_json::from_slice::<String>(&body)?;
-
-                    return Err(Error::Unauthorized(message))?;
+                    return Err(Error::Unauthorized(response_text(response).await))?;
                 }
                 StatusCode::BAD_REQUEST => {
-                    return Err(Error::BadRequest(handle_message(response).await))?;
+                    return Err(Error::BadRequest(response_text(response).await))?;
                 }
                 _ => {
                     return Err(eyre!(
@@ -131,7 +128,7 @@ async fn execute() -> Result<std::process::ExitCode> {
                         {}\
                         ",
                         response_status,
-                        handle_message(response).await,
+                        response_text(response).await,
                     ));
                 }
             }
@@ -153,7 +150,7 @@ async fn execute() -> Result<std::process::ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-async fn handle_message(res: Response) -> String {
+async fn response_text(res: Response) -> String {
     if let Ok(message) = res.text().await {
         message
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,16 +121,19 @@ async fn execute() -> Result<std::process::ExitCode> {
                     return Err(Error::Unauthorized(message))?;
                 }
                 _ => {
-                    let body = response.bytes().await?;
-                    let message = serde_json::from_slice::<String>(&body)?;
-                    return Err(eyre!(
-                        "\
-                        Status {} from metadata POST\n\
-                        {}\
-                    ",
-                        response_status,
-                        message
-                    ));
+                    return if let Ok(body) = response.bytes().await {
+                        let message = serde_json::from_slice::<String>(&body)?;
+                        Err(eyre!(
+                            "\
+                            Status {} from metadata POST\n\
+                            {}\
+                        ",
+                            response_status,
+                            message
+                        ))
+                    } else {
+                        Err(eyre!("Status {} from metadata POST", response_status))
+                    }
                 }
             }
         }


### PR DESCRIPTION
I'm currently getting this error in Gitlab:

```
Error: 
   0: expected value at line 1 column 1
Location:
   src/main.rs:125
```

The offending section: https://github.com/DeterminateSystems/flakehub-push/blob/main/src/main.rs#L123-L134

These changes should at least begin to unblock the as-yet-inscrutable issues here: https://gitlab.com/DeterminateSystems/testing/flakehub-push-test-subrepo/-/jobs/7194111999