### PR TITLE
Move development docs into separate Markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,9 @@ jobs:
 | `source-tag`        | The tag of `flakehub-push` to use. Conflicts with all other `source-*` options.                                                                                                                                                                                                                                                                                                                                                                                         | string        |           |                            |
 | `source-url`        | A URL pointing to a `flakehub-push` binary. Overrides all other `source-*` options.                                                                                                                                                                                                                                                                                                                                                                                     | string        |           |                            |
 
-## Development against a local Flakehub server
+## Developing `flakehub-push`
 
-Assuming the dev environment is running as described in the flakehub repo:
-
-```bash
-export FLAKEHUB_PUSH_GITHUB_TOKEN="<secret>"
-cargo run -- \
-  --visibility public \
-  --tag v0.1.0 \
-  --repository DeterminateSystems/nix-installer \
-  --git-root ../nix-installer \
-  --jwt-issuer-uri http://localhost:8081/jwt/token \
-  --host http://localhost:8080
-```
+See the [development docs](./docs/development.md).
 
 [flakehub]: https://flakehub.com
 [flakes]: https://zero-to-nix.com/concepts/flakes

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,15 @@
+## Developing `flakehub-push`
+
+You can run `flakehub-push` against a Flakehub server running locally.
+Assuming the dev environment is running as described in the FlakeHub repo:
+
+```bash
+export FLAKEHUB_PUSH_GITHUB_TOKEN="<secret>"
+cargo run -- \
+  --visibility public \
+  --tag v0.1.0 \
+  --repository DeterminateSystems/nix-installer \
+  --git-root ../nix-installer \
+  --jwt-issuer-uri http://localhost:8081/jwt/token \
+  --host http://localhost:8080
+```


### PR DESCRIPTION
Best to leave this information out of the average reader's hot path.
