### PR TITLE
Make it easier to test without GitHub or a local FlakeHub

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,3 +13,17 @@ cargo run -- \
   --jwt-issuer-uri http://localhost:8081/jwt/token \
   --host http://localhost:8080
 ```
+
+To test evaluation of a local flake without fetching anything from
+GitHub, and writing the tarball and metadata to a local directory
+instead of FlakeHub, do:
+
+```bash
+cargo run -- \
+  --visibility public \
+  --repository foo/bar \
+  --tag v0.0.1 \
+  --git-root /path/to/repo \
+  --directory /path/to/repo/flake \
+  --dest-dir /tmp/out
+```

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -337,8 +337,6 @@ impl FlakeHubPushCli {
             ExecutionEnvironment::GitHub
         } else if std::env::var("GITLAB_CI").ok().is_some() {
             ExecutionEnvironment::GitLab
-        } else if cli.dest_dir.0.is_some() {
-            ExecutionEnvironment::Fake
         } else {
             ExecutionEnvironment::LocalGitHub
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -118,6 +118,10 @@ pub(crate) struct FlakeHubPushCli {
         default_value_t = false
     )]
     pub(crate) disable_rename_subgroups: bool,
+
+    /// Write the tarball to a directory instead of pushing it to FlakeHub.
+    #[clap(long, env = "FLAKEHUB_DEST_DIR", value_parser = PathBufToNoneParser, default_value = "")]
+    pub(crate) dest_dir: OptionPathBuf,
 }
 
 #[derive(Clone, Debug)]

--- a/src/release_metadata.rs
+++ b/src/release_metadata.rs
@@ -1,3 +1,13 @@
+use std::collections::HashSet;
+
+use color_eyre::eyre::{eyre, Context as _, Result};
+
+use crate::cli::FlakeHubPushCli;
+use crate::flake_info::FlakeMetadata;
+use crate::flakehub_client::Tarball;
+use crate::git_context::GitContext;
+use crate::github::graphql::{MAX_LABEL_LENGTH, MAX_NUM_TOTAL_LABELS};
+use crate::push_context::ExecutionEnvironment;
 use crate::Visibility;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -22,6 +32,155 @@ pub(crate) struct ReleaseMetadata {
     // A result of combining the labels specified on the CLI via the the GitHub Actions config
     // and the labels associated with the GitHub repo (they're called "topics" in GitHub parlance).
     pub(crate) labels: Vec<String>,
+}
+
+impl ReleaseMetadata {
+    pub async fn new(
+        cli: &FlakeHubPushCli,
+        git_ctx: &GitContext,
+        exec_env: Option<&ExecutionEnvironment>,
+    ) -> Result<(Self, Tarball)> {
+        let local_git_root = cli.resolve_local_git_root()?;
+        let subdir = cli.subdir_from_git_root(&local_git_root)?;
+
+        // flake_dir is an absolute path of flake_root(aka git_root)/subdir
+        let flake_dir = local_git_root.join(&subdir);
+
+        let flake_metadata = FlakeMetadata::from_dir(&flake_dir, cli.my_flake_is_too_big)
+            .await
+            .wrap_err("Getting flake metadata")?;
+        tracing::debug!("Got flake metadata: {:?}", flake_metadata);
+
+        // sanity checks
+        flake_metadata
+            .check_evaluates()
+            .await
+            .wrap_err("failed to evaluate all system attrs of the flake")?;
+        flake_metadata
+            .check_lock_if_exists()
+            .await
+            .wrap_err("failed to evaluate all system attrs of the flake")?;
+
+        let Some(commit_count) = git_ctx.revision_info.commit_count else {
+            return Err(eyre!("Could not determine commit count, this is normally determined via the `--git-root` argument or via the GitHub API"));
+        };
+
+        let description = flake_metadata
+            .metadata_json
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .map(|s| s.to_string());
+
+        let flake_outputs = flake_metadata.outputs(cli.include_output_paths).await?;
+        tracing::debug!("Got flake outputs: {:?}", flake_outputs);
+
+        let readme = flake_metadata.get_readme_contents().await?;
+
+        let Some(ref repository) = cli.repository.0 else {
+            return Err(eyre!("Could not determine repository name, pass `--repository` formatted like `determinatesystems/flakehub-push`"));
+        };
+
+        let (upload_name, _project_owner, _project_name) = crate::push_context::determine_names(
+            &cli.name.0,
+            repository,
+            cli.disable_rename_subgroups,
+        )?;
+
+        let visibility = cli.visibility()?;
+
+        let labels = if let Some(exec_env) = exec_env {
+            Self::merged_labels(cli, git_ctx, exec_env)
+        } else {
+            Vec::new()
+        };
+
+        let release_metadata = ReleaseMetadata {
+            commit_count,
+            description,
+            outputs: flake_outputs.0,
+            raw_flake_metadata: flake_metadata.metadata_json.clone(),
+            readme,
+            // TODO(colemickens): remove this confusing, redundant field (FH-267)
+            repo: upload_name.to_string(),
+            revision: git_ctx.revision_info.revision.clone(),
+            visibility,
+            mirrored: cli.mirror,
+            source_subdirectory: Some(subdir.to_str().map(|d| d.to_string()).ok_or(
+                color_eyre::eyre::eyre!("Directory {:?} is not a valid UTF-8 string", subdir),
+            )?),
+            spdx_identifier: git_ctx.spdx_expression.clone(),
+            labels,
+        };
+
+        let flake_tarball = flake_metadata
+            .flake_tarball()
+            .wrap_err("Making release tarball")?;
+
+        Ok((release_metadata, flake_tarball))
+    }
+
+    fn merged_labels(
+        cli: &FlakeHubPushCli,
+        git_ctx: &GitContext,
+        exec_env: &ExecutionEnvironment,
+    ) -> Vec<String> {
+        let mut labels: HashSet<_> = cli
+            .extra_labels
+            .clone()
+            .into_iter()
+            .filter(|v| !v.is_empty())
+            .collect();
+        let extra_tags: HashSet<_> = cli
+            .extra_tags
+            .clone()
+            .into_iter()
+            .filter(|v| !v.is_empty())
+            .collect();
+
+        if !extra_tags.is_empty() {
+            let message = "`extra-tags` is deprecated and will be removed in the future. Please use `extra-labels` instead.";
+            tracing::warn!("{message}");
+
+            if matches!(&exec_env, ExecutionEnvironment::GitHub) {
+                println!("::warning::{message}");
+            }
+
+            if labels.is_empty() {
+                labels = extra_tags;
+            } else {
+                let message =
+                    "Both `extra-tags` and `extra-labels` were set; `extra-tags` will be ignored.";
+                tracing::warn!("{message}");
+
+                if matches!(exec_env, ExecutionEnvironment::GitHub) {
+                    println!("::warning::{message}");
+                }
+            }
+        }
+
+        // Get the "topic" labels from git_ctx, extend local mut labels
+        let topics = &git_ctx.repo_topics;
+        labels = labels
+            .into_iter()
+            .chain(topics.iter().cloned())
+            .collect::<HashSet<String>>();
+
+        // Here we merge explicitly user-supplied labels and the labels ("topics")
+        // associated with the repo. Duplicates are excluded and all
+        // are converted to lower case.
+        let merged_labels: Vec<String> = labels
+            .into_iter()
+            .take(MAX_NUM_TOTAL_LABELS)
+            .map(|s| s.trim().to_lowercase())
+            .filter(|t: &String| {
+                !t.is_empty()
+                    && t.len() <= MAX_LABEL_LENGTH
+                    && t.chars().all(|c| c.is_alphanumeric() || c == '-')
+            })
+            .collect();
+
+        merged_labels
+    }
 }
 
 // TODO(review,colemickens): I don't really undersatnd why these are nededed??? we don't need the OptionString-y stuff since this isn't GHA adjacent?


### PR DESCRIPTION
Passing `--dest-dir` will write the tarball and metadata to the specified directory instead of uploading to FlakeHub. This will also avoid getting revision info from GitHub, which is useful when testing against a local repo that hasn't been pushed to GitHub.