### PR TITLE
ci: disable GHA cache

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
       - name: Install pnpm dependencies
         run: nix develop --command pnpm install
       - name: Check formatting

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,8 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
 
       - name: "Nix formatting"
         run: git ls-files '*.nix' | nix develop --command xargs nixpkgs-fmt --check
@@ -64,6 +66,8 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
 
       - name: Build package
         run: "nix build .# -L --fallback"

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "DeterminateSystems/nix-installer-action@main"
       - uses: "DeterminateSystems/magic-nix-cache-action@main"
+        with:
+          use-gha-cache: false
       - uses: "DeterminateSystems/flakehub-push@main"
         with:
           name: "DeterminateSystems/flakehub-push"

--- a/.github/workflows/production-test.yml
+++ b/.github/workflows/production-test.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
 
       - uses: actions/download-artifact@v4.1.7
         with:


### PR DESCRIPTION
We have FlakeHub Cache, which is not ratelimited, and our release process uses GHA to store the artifacts, so hitting the rate limit means we can't release.