### PR TITLE
ci: fixup upload-artifact action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
         run: "nix build .# -L --fallback"
 
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4.4.0
         with:
           # Artifact name
           name: flakehub-push-X64-Linux


### PR DESCRIPTION
The download-artifact and upload-artifact actions need to be the same version.