### PR TITLE
Export the exact flakeref as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ There are two ways to get started configuring this Action:
 
 Although the `flakehub-push` Action requires little configuration, you may benefit from assembling it with our friendly UI at [flakehub.com/new][wizard].
 
+## Integration
+
+This action sets the `flakeref` output to the exact name and version that was published.
+The flake reference can be used in subsequent steps or workflows as part of a deployment process.
+
+## More Information
+
 ### Manual configuration
 
 The example workflow configuration below pushes new tags matching the conventional format&mdash;such as `v1.0.0` or `v0.1.0-rc4`&mdash;to [Flakehub]:

--- a/src/github_actions.rs
+++ b/src/github_actions.rs
@@ -1,0 +1,31 @@
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("The `GITHUB_OUTPUT` environment variable is unset.")]
+    GithubOutputUnset,
+
+    #[error("Failure opening {0:?}: {1}")]
+    OpenFile(std::ffi::OsString, std::io::Error),
+
+    #[error("Writing to {0:?}: {1}")]
+    WriteFile(std::ffi::OsString, std::io::Error),
+}
+
+pub(crate) async fn set_output<'a>(name: &'a str, value: &'a str) -> Result<(), Error> {
+    let output_path = std::env::var_os("GITHUB_OUTPUT").ok_or(Error::GithubOutputUnset)?;
+    let mut fh = tokio::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&output_path)
+        .await
+        .map_err(|e| Error::OpenFile(output_path.clone(), e))?;
+
+    fh.write_all(format!("{}={}\n", name, value).as_bytes())
+        .await
+        .map_err(|e| Error::WriteFile(output_path, e))?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod flakehub_auth_fake;
 mod flakehub_client;
 mod git_context;
 mod github;
+mod github_actions;
 mod gitlab;
 mod push_context;
 mod release_metadata;
@@ -180,6 +181,15 @@ async fn execute() -> Result<std::process::ExitCode> {
         ctx.upload_name,
         ctx.release_version
     );
+
+    if let Err(e) = github_actions::set_output(
+        "flakeref",
+        &format!("{}/{}", ctx.upload_name, ctx.release_version),
+    )
+    .await
+    {
+        tracing::warn!("Failed to set the `flakeref` output: {}", e);
+    }
 
     Ok(ExitCode::SUCCESS)
 }


### PR DESCRIPTION
```yaml
      - uses: "DeterminateSystems/flakehub-push@main"
        id: push
        with:
          rolling: true
          name: grahamc/test5
          visibility: "private"
          source-pr: 168
      - run: |
          echo ${{ steps.push.outputs.flakeref }}
```

![CleanShot 2024-09-24 at 09 46 47](https://github.com/user-attachments/assets/e550fd2f-4d89-4904-9b29-439c915b9879)
