### PR TITLE
Add a method to bypass GitHub API

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -88,6 +88,10 @@ inputs:
     description: Please read the source code of flakehub-push before using this.
     required: false
     default: false
+  disable-github-api:
+    description: Disables communicating to the GitHub API.
+    required: false
+    default: false
 
   # Used to construct the binary download URL
   source-binary:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,6 +90,14 @@ pub(crate) struct FlakeHubPushCli {
 
     #[clap(
         long,
+        env = "FLAKEHUB_PUSH_DISABLE_GITHUB_API",
+        value_parser = EmptyBoolParser,
+        default_value_t = false
+    )]
+    pub(crate) disable_github_api: bool,
+
+    #[clap(
+        long,
         env = "FLAKEHUB_PUSH_ERROR_ON_CONFLICT",
         value_parser = EmptyBoolParser,
         default_value_t = false

--- a/src/github/graphql/mod.rs
+++ b/src/github/graphql/mod.rs
@@ -143,7 +143,7 @@ impl GithubGraphqlDataQuery {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct GithubGraphqlDataResult {
     pub(crate) revision: String,
     pub(crate) rev_count: i64,

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -27,6 +27,7 @@ type ExecutionEnvironment = {
   FLAKEHUB_PUSH_ROLLING?: string;
   FLAKEHUB_PUSH_MIRROR?: string;
   FLAKEHUB_PUSH_ROLLING_MINOR?: string;
+  FLAKEHUB_PUSH_DISABLE_GITHUB_API?: string;
   GITHUB_CONTEXT?: string;
 };
 
@@ -50,6 +51,7 @@ class FlakeHubPushAction extends DetSysAction {
   private mirror: boolean;
   private name: string | null;
   private rollingMinor: number | null;
+  private disableGitHubAPI: boolean;
 
   constructor() {
     super({
@@ -79,6 +81,7 @@ class FlakeHubPushAction extends DetSysAction {
     this.mirror = inputs.getBool("mirror");
     this.name = inputs.getStringOrNull("name");
     this.rollingMinor = inputs.getNumberOrNull("rolling-minor");
+    this.disableGitHubAPI = inputs.getBool("disable-github-api");
   }
 
   async main(): Promise<void> {
@@ -133,6 +136,7 @@ class FlakeHubPushAction extends DetSysAction {
     env.FLAKEHUB_PUSH_INCLUDE_OUTPUT_PATHS = this.includeOutputPaths.toString();
     env.FLAKEHUB_PUSH_ROLLING = this.rolling.toString();
     env.FLAKEHUB_PUSH_MIRROR = this.mirror.toString();
+    env.FLAKEHUB_PUSH_DISABLE_GITHUB_API = this.disableGitHubAPI.toString();
 
     env.GITHUB_CONTEXT = JSON.stringify(actionsGithub.context);
 


### PR DESCRIPTION
Adds a method to bypass the GitHub API, useful if you add commits to a Flake that you don't want to push to GitHub but want in FlakeHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `disable-github-api` option to disable GitHub API communication during execution. Configure via CLI flag, action input, or `FLAKEHUB_PUSH_DISABLE_GITHUB_API` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->