### PR TITLE
flake-schemas: 0.2.0 -> 0.3.0 for null what support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "flake-schemas"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b03a421492bf619876daa31c52b172a48af04cc837bc2576c6f2bb685a1768"
+checksum = "1afeee260aba421e91f6cc9f90afe77245c4497bb06f3c2e831c69d99bd37764"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0.56"
 url = { version = "2.5.0", features = ["serde"] }
 http = "1.1.0"
 gitlab = "0.1706.0"
-flake-schemas = "0.2.0"
+flake-schemas = "0.3.0"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated flake-schemas dependency to version 0.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->