### PR TITLE
Autodiscover the GitHub GraphQL API URL base

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -131,6 +131,10 @@ pub(crate) struct FlakeHubPushCli {
     /// Write the tarball to a directory instead of pushing it to FlakeHub.
     #[clap(long, env = "FLAKEHUB_DEST_DIR", value_parser = PathBufToNoneParser, default_value = "")]
     pub(crate) dest_dir: OptionPathBuf,
+
+    /// The GitHub GraphQL API URL base.
+    #[clap(long, env = "FLAKEHUB_GITHUB_GRAPHQL_URL", value_parser = StringToNoneParser, default_value = "")]
+    pub(crate) github_graphql_url: OptionString,
 }
 
 #[derive(Clone, Debug)]
@@ -301,6 +305,14 @@ impl FlakeHubPushCli {
             if let Ok(env_val) = std::env::var(env_key) {
                 tracing::debug!(repository = %env_val, "Set via `${env_key}`");
                 self.tag.0 = Some(env_val);
+            }
+        }
+
+        if self.github_graphql_url.0.is_none() {
+            let env_key = "GITHUB_GRAPHQL_URL";
+            if let Ok(env_val) = std::env::var(env_key) {
+                tracing::debug!(repository = %env_val, "Set via `${env_key}`");
+                self.github_graphql_url.0 = Some(env_val);
             }
         }
     }

--- a/src/github/graphql/mod.rs
+++ b/src/github/graphql/mod.rs
@@ -3,7 +3,6 @@
 use color_eyre::eyre::{eyre, WrapErr};
 use graphql_client::GraphQLQuery;
 
-pub(crate) const GITHUB_ENDPOINT: &str = "https://api.github.com/graphql";
 pub(crate) const MAX_LABEL_LENGTH: usize = 50;
 pub(crate) const MAX_NUM_TOTAL_LABELS: usize = 25;
 const MAX_NUM_EXTRA_TOPICS: i64 = 20;
@@ -25,6 +24,7 @@ impl GithubGraphqlDataQuery {
     ))]
     pub(crate) async fn get(
         reqwest_client: &reqwest::Client,
+        graphql_endpoint: &str,
         bearer_token: &str,
         project_owner: &str,
         project_name: &str,
@@ -39,11 +39,15 @@ impl GithubGraphqlDataQuery {
                 max_num_topics: MAX_NUM_EXTRA_TOPICS,
             };
 
-            tracing::debug!(?variables); // TODO remove
+            tracing::debug!(
+                ?variables,
+                graphql_endpoint,
+                "Building and sending GraphQL query"
+            );
 
             let query = GithubGraphqlDataQuery::build_query(variables);
             let reqwest_response = reqwest_client
-                .post(GITHUB_ENDPOINT)
+                .post(graphql_endpoint)
                 .bearer_auth(bearer_token)
                 .json(&query)
                 .send()

--- a/src/push_context.rs
+++ b/src/push_context.rs
@@ -96,8 +96,13 @@ impl PushContext {
                     .clone()
                     .expect("failed to get github token when running in GitHub Actions");
 
+                let Some(github_graphql_url) = cli.github_graphql_url.0.as_ref() else {
+                    return Err(eyre!("`--github-graphql-url` was not specified and could not be populated from the GITHUB_GRAPHQL_URL environment variable"));
+                };
+
                 let github_graphql_data_result = GithubGraphqlDataQuery::get(
                     &client,
+                    github_graphql_url,
                     &github_token,
                     &project_owner,
                     &project_name,
@@ -133,8 +138,13 @@ impl PushContext {
                     .clone()
                     .expect("failed to get github token when running locally");
 
+                let Some(github_graphql_url) = cli.github_graphql_url.0.as_ref() else {
+                    return Err(eyre!("`--github-graphql-url` was not specified and could not be populated from the GITHUB_GRAPHQL_URL environment variable"));
+                };
+
                 let github_graphql_data_result = GithubGraphqlDataQuery::get(
                     &client,
+                    github_graphql_url,
                     &github_token,
                     &project_owner,
                     &project_name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub GraphQL endpoint is configurable via the --github-graphql-url CLI flag or FLAKEHUB_GITHUB_GRAPHQL_URL environment variable to support custom/alternative endpoints.
* **Bug Fixes**
  * Startup now validates that a GraphQL endpoint is provided and fails early with a clear error if missing.
* **Other**
  * Added debug logging to show which GraphQL endpoint is being used when making requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->