### PR TITLE
flake: rewrite Nix-store libiconv path in macOS binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,23 @@
                 ."${pkgs.stdenv.system}" or null;
               CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
             }
+            // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+              # The Darwin build links against Nix-store libiconv, baking the
+              # store path into the binary's load commands. When the artifact
+              # is distributed standalone (as this action does), that store
+              # path doesn't exist on the consumer's machine and dyld fails.
+              # Rewrite the reference to the system-provided libiconv, which
+              # is always present on macOS.
+              postInstall = ''
+                for bin in $(find "$out/bin" -type f); do
+                  linked=$(otool -L "$bin" | awk '/\/nix\/store\/.*libiconv.*\.dylib/ {print $1}') || true
+                  if [ -n "$linked" ]; then
+                    echo "Rewriting $bin: $linked -> /usr/lib/libiconv.2.dylib"
+                    install_name_tool -change "$linked" "/usr/lib/libiconv.2.dylib" "$bin"
+                  fi
+                done
+              '';
+            }
           );
         }
       );


### PR DESCRIPTION
## Problem

Consumers of this Action on `macos-latest` runners fail with:

```
dyld[…]: Library not loaded: /nix/store/<hash>-libiconv-109.100.2/lib/libiconv.2.dylib
  Referenced from: <…> /Users/runner/work/_temp/flakehub-push-…/flakehub-push
  Reason: tried: '/nix/store/<hash>-libiconv-109.100.2/lib/libiconv.2.dylib' (no such file), …
```

The Darwin build in `flake.nix` links dynamically against `pkgs.libiconv`, which bakes the `/nix/store/<hash>-libiconv-*/lib/libiconv.2.dylib` path into the binary's `LC_LOAD_DYLIB` entry. That artifact is then uploaded via `push-artifact-ids` and fetched as a standalone binary by action consumers. On their runners the specific store path doesn't exist and dyld aborts on the first invocation.

Linux is unaffected because its build already uses `+crt-static` against a musl target.

## Fix

Add a Darwin-only `postInstall` that rewrites any `/nix/store/*libiconv*.dylib` references in the binary's install names to `/usr/lib/libiconv.2.dylib`, which is always present on macOS. This mirrors the pattern used by e.g. https://github.com/gnosis/gnosis_vpn-client/pull/502 for the same class of bug.

## Verification

- `nix flake show --all-systems` evaluates cleanly for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
- `nixfmt --check flake.nix` passes.
- I don't have a Darwin machine handy to `nix build` and inspect `otool -L` on the result, but the postInstall is a no-op when no matching reference exists, and mirrors the exact pattern proven in the linked gnosis PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS binary compatibility by optimizing library dependency resolution on Apple systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->