### PR TITLE
fixup: rewrite libiconv reference on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,42 +64,54 @@
 
       packages = forAllSystems (
         { system, pkgs, ... }:
+        let
+          sharedAttrs = {
+            pname = "flakehub-push";
+            version = "0.1.0";
+            src = pkgs.craneLib.path (
+              builtins.path {
+                name = "flakehub-push-source";
+                path = inputs.self;
+                filter = (
+                  path: type:
+                  baseNameOf path != "ts"
+                  && baseNameOf path != "dist"
+                  && baseNameOf path != ".github"
+                  && path != "flake.nix"
+                );
+              }
+            );
+
+            buildInputs = pkgs.lib.optionals (pkgs.stdenv.isDarwin) (
+              with pkgs;
+              [
+                libiconv
+              ]
+            );
+          }
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            CARGO_BUILD_TARGET =
+              {
+                "x86_64-linux" = "x86_64-unknown-linux-musl";
+                "aarch64-linux" = "aarch64-unknown-linux-musl";
+              }
+              ."${pkgs.stdenv.system}" or null;
+            CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+          };
+        in
         rec {
           default = flakehub-push;
 
           flakehub-push = pkgs.craneLib.buildPackage (
-            {
-              pname = "flakehub-push";
-              version = "0.1.0";
-              src = pkgs.craneLib.path (
-                builtins.path {
-                  name = "determinate-nixd-source";
-                  path = inputs.self;
-                  filter = (
-                    path: type:
-                    baseNameOf path != "ts"
-                    && baseNameOf path != "dist"
-                    && baseNameOf path != ".github"
-                    && path != "flake.nix"
-                  );
-                }
-              );
-
-              buildInputs = pkgs.lib.optionals (pkgs.stdenv.isDarwin) (
-                with pkgs;
-                [
-                  libiconv
-                ]
-              );
-            }
-            // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-              CARGO_BUILD_TARGET =
-                {
-                  "x86_64-linux" = "x86_64-unknown-linux-musl";
-                  "aarch64-linux" = "aarch64-unknown-linux-musl";
-                }
-                ."${pkgs.stdenv.system}" or null;
-              CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+            sharedAttrs
+            // {
+              cargoArtifacts = pkgs.craneLib.buildDepsOnly sharedAttrs;
+              postFixup = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+                install_name_tool -change \
+                  "$(otool -L $out/bin/flakehub-push | grep libiconv | awk '{print $1}')" \
+                  /usr/lib/libiconv.2.dylib \
+                  $out/bin/flakehub-push
+              '';
             }
           );
         }


### PR DESCRIPTION
Closes https://github.com/DeterminateSystems/flakehub-push/pull/305.

A different approach that is much smaller and more targeted; mirrors what we do in flake-checker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS binary compatibility with system libraries so the flakehub-push tool runs correctly on modern macOS.
  * Improved packaging reliability for native and static Linux builds, reducing startup/install issues across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->