### PR TITLE
Drop cargo-watch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,7 +125,6 @@
               [
                 rustfmt
                 cargo-outdated
-                cargo-watch
                 rust-analyzer
                 rustc
                 cargo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `cargo-watch` development tool from the default development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->